### PR TITLE
Feature resize

### DIFF
--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -214,9 +214,9 @@ void WispEntry()
 
 	window->SetResizeCallback([&](std::uint32_t width, std::uint32_t height)
 	{
-		//render_system->WaitForAllPreviousWork();
-		//frame_graph.Resize(*render_system.get(), width, height);
-		//render_system->Resize(width, height);
+		render_system->WaitForAllPreviousWork();
+		frame_graph.Resize(*render_system.get(), width, height);
+		render_system->Resize(width, height);
 	});
 
 	float t = 0;

--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -13,6 +13,8 @@ bool open1 = true;
 bool open2 = true;
 bool open_console = false;
 bool show_imgui = true;
+bool fullscreen = false;
+
 char message_buffer[600];
 
 std::unique_ptr<wr::D3D12RenderSystem> render_system;
@@ -76,6 +78,13 @@ void RenderEditor()
 	if (open2)
 	{
 		ImGui::Begin("Logging Example", &open2);
+		
+		if (ImGui::Button("Toggle Fullscreen"))
+		{
+			fullscreen = !fullscreen;
+			render_system->RequestFullscreenChange(fullscreen);
+		}
+
 		ImGui::InputText("Message", message_buffer, 600);
 		if (ImGui::Button("LOG (Message)")) LOG(message_buffer);
 		if (ImGui::Button("LOGW (Warning)")) LOGW(message_buffer);
@@ -205,8 +214,9 @@ void WispEntry()
 
 	window->SetResizeCallback([&](std::uint32_t width, std::uint32_t height)
 	{
-		frame_graph.Resize(*render_system.get(), width, height);
-		render_system->Resize(width, height);
+		//render_system->WaitForAllPreviousWork();
+		//frame_graph.Resize(*render_system.get(), width, height);
+		//render_system->Resize(width, height);
 	});
 
 	float t = 0;

--- a/imgui.ini
+++ b/imgui.ini
@@ -5,7 +5,7 @@ Collapsed=0
 
 [Window][Theme]
 Pos=26,21
-Size=6,24
+Size=6,23
 Collapsed=0
 DockId=0x00000009,0
 
@@ -15,14 +15,14 @@ Size=32,32
 Collapsed=0
 
 [Window][ImGui Details]
-Pos=26,47
-Size=6,6
+Pos=26,46
+Size=6,7
 Collapsed=0
 DockId=0x0000000A,0
 
 [Window][Logging Example]
-Pos=0,48
-Size=24,5
+Pos=0,46
+Size=24,7
 Collapsed=0
 DockId=0x00000008,0
 
@@ -33,31 +33,31 @@ Collapsed=0
 
 [Window][Shader Registry]
 Pos=0,21
-Size=11,12
+Size=11,11
 Collapsed=0
 DockId=0x00000001,0
 
 [Window][Pipeline Registry]
-Pos=0,35
-Size=11,11
+Pos=0,34
+Size=11,10
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][Root Signature Registry]
 Pos=0,21
-Size=11,12
+Size=11,11
 Collapsed=0
 DockId=0x00000001,1
 
 [Window][Hardware Info]
 Pos=26,21
-Size=6,24
+Size=6,23
 Collapsed=0
 DockId=0x00000009,1
 
 [Window][DirectX 12 Settings]
 Pos=26,21
-Size=6,24
+Size=6,23
 Collapsed=0
 DockId=0x00000009,2
 
@@ -69,13 +69,13 @@ Collapsed=0
 [Docking][Data]
 DockSpace         ID=0x4DDED0D8 Pos=0,21 Size=32,32 Split=X SelectedTab=0x56B4C80C
   DockNode        ID=0x00000003 Parent=0x4DDED0D8 SizeRef=1027,699 Split=Y
-    DockNode      ID=0x00000007 Parent=0x00000003 SizeRef=1280,575 Split=X
+    DockNode      ID=0x00000007 Parent=0x00000003 SizeRef=1280,543 Split=X
       DockNode    ID=0x00000005 Parent=0x00000007 SizeRef=233,527 Split=Y SelectedTab=0x1FA76273
         DockNode  ID=0x00000001 Parent=0x00000005 SizeRef=259,291 SelectedTab=0x1FA76273
-        DockNode  ID=0x00000002 Parent=0x00000005 SizeRef=259,282 SelectedTab=0xAE33D025
+        DockNode  ID=0x00000002 Parent=0x00000005 SizeRef=259,250 SelectedTab=0xAE33D025
       DockNode    ID=0x00000006 Parent=0x00000007 SizeRef=1306,527 CentralNode=1
-    DockNode      ID=0x00000008 Parent=0x00000003 SizeRef=1280,122 SelectedTab=0xB420DC18
+    DockNode      ID=0x00000008 Parent=0x00000003 SizeRef=1280,154 SelectedTab=0xB420DC18
   DockNode        ID=0x00000004 Parent=0x4DDED0D8 SizeRef=251,699 Split=Y SelectedTab=0x070A839D
-    DockNode      ID=0x00000009 Parent=0x00000004 SizeRef=251,569 SelectedTab=0x070A839D
-    DockNode      ID=0x0000000A Parent=0x00000004 SizeRef=251,128 SelectedTab=0x45C34A56
+    DockNode      ID=0x00000009 Parent=0x00000004 SizeRef=251,545 SelectedTab=0x070A839D
+    DockNode      ID=0x0000000A Parent=0x00000004 SizeRef=251,152 SelectedTab=0x45C34A56
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -70,10 +70,10 @@ Collapsed=0
 DockSpace         ID=0x4DDED0D8 Pos=0,21 Size=32,32 Split=X SelectedTab=0x56B4C80C
   DockNode        ID=0x00000003 Parent=0x4DDED0D8 SizeRef=1027,699 Split=Y
     DockNode      ID=0x00000007 Parent=0x00000003 SizeRef=1280,575 Split=X
-      DockNode    ID=0x00000005 Parent=0x00000007 SizeRef=259,527 Split=Y SelectedTab=0x1FA76273
+      DockNode    ID=0x00000005 Parent=0x00000007 SizeRef=233,527 Split=Y SelectedTab=0x1FA76273
         DockNode  ID=0x00000001 Parent=0x00000005 SizeRef=259,291 SelectedTab=0x1FA76273
         DockNode  ID=0x00000002 Parent=0x00000005 SizeRef=259,282 SelectedTab=0xAE33D025
-      DockNode    ID=0x00000006 Parent=0x00000007 SizeRef=766,527 CentralNode=1
+      DockNode    ID=0x00000006 Parent=0x00000007 SizeRef=1306,527 CentralNode=1
     DockNode      ID=0x00000008 Parent=0x00000003 SizeRef=1280,122 SelectedTab=0xB420DC18
   DockNode        ID=0x00000004 Parent=0x4DDED0D8 SizeRef=251,699 Split=Y SelectedTab=0x070A839D
     DockNode      ID=0x00000009 Parent=0x00000004 SizeRef=251,569 SelectedTab=0x070A839D

--- a/src/d3d12/d3d12_command_queue.cpp
+++ b/src/d3d12/d3d12_command_queue.cpp
@@ -33,7 +33,9 @@ namespace wr::d3d12
 
 		cmd_queue->m_native->ExecuteCommandLists(native_lists.size(), native_lists.data());
 
+		fence->m_fence_value++;
 		Signal(fence, cmd_queue);
+
 	}
 
 	void Destroy(CommandQueue* cmd_queue)

--- a/src/d3d12/d3d12_functions.hpp
+++ b/src/d3d12/d3d12_functions.hpp
@@ -66,7 +66,7 @@ namespace wr::d3d12
 	// RenderWindow
 	[[nodiscard]] RenderWindow* CreateRenderWindow(Device* device, HWND window, CommandQueue* cmd_queue, unsigned int num_back_buffers);
 	[[nodiscard]] RenderWindow* CreateRenderWindow(Device* device, IUnknown* window, CommandQueue* cmd_queue, unsigned int num_back_buffers);
-	void Resize(RenderWindow* render_window, Device* device, unsigned int width, unsigned int height);
+	void Resize(RenderWindow* render_window, Device* device, unsigned int width, unsigned int height, bool fullscreen);
 	void Present(RenderWindow* render_window, Device* device);
 	void Destroy(RenderWindow* render_window);
 
@@ -86,6 +86,7 @@ namespace wr::d3d12
 
 	// Viewport
 	[[nodiscard]] Viewport CreateViewport(int width, int height);
+	void ResizeViewport(Viewport& viewport, int width, int height);
 
 	// Shader
 	[[nodiscard]] Shader* LoadShader(ShaderType type, std::string const & path, std::string const & entry = "main");

--- a/src/d3d12/d3d12_render_target.cpp
+++ b/src/d3d12/d3d12_render_target.cpp
@@ -191,7 +191,7 @@ namespace wr::d3d12
 		}
 		DestroyRenderTargetViews((*render_target));
 
-		auto new_render_target = CreateRenderTarget(device, width, height, (*render_target)->m_create_info);
+		(*render_target) = CreateRenderTarget(device, width, height, (*render_target)->m_create_info);
 	}
 
 	void IncrementFrameIdx(RenderTarget* render_target)

--- a/src/d3d12/d3d12_render_window.cpp
+++ b/src/d3d12/d3d12_render_window.cpp
@@ -103,7 +103,7 @@ namespace wr::d3d12
 		return render_window;
 	}
 
-	void Resize(RenderWindow* render_window, Device* device, unsigned int width, unsigned int height)
+	void Resize(RenderWindow* render_window, Device* device, unsigned int width, unsigned int height, bool fullscreen)
 	{
 		DestroyDepthStencilBuffer(render_window);
 		DestroyRenderTargetViews(render_window);
@@ -119,6 +119,7 @@ namespace wr::d3d12
 
 		CreateRenderTargetViews(render_window, device, width, height);
 		CreateDepthStencilBuffer(render_window, device, width, height);
+	
 	}
 
 	void Present(RenderWindow* render_window, Device* device)

--- a/src/d3d12/d3d12_render_window.cpp
+++ b/src/d3d12/d3d12_render_window.cpp
@@ -90,6 +90,8 @@ namespace wr::d3d12
 		render_window->m_swap_chain = static_cast<IDXGISwapChain4*>(temp_swap_chain);
 		render_window->m_frame_idx = (render_window->m_swap_chain)->GetCurrentBackBufferIndex();
 
+		render_window->m_swap_chain->SetMaximumFrameLatency(num_back_buffers);
+
 		render_window->m_render_targets.resize(num_back_buffers);
 		for (decltype(num_back_buffers) i = 0; i < num_back_buffers; i++)
 		{

--- a/src/d3d12/d3d12_render_window.cpp
+++ b/src/d3d12/d3d12_render_window.cpp
@@ -121,7 +121,6 @@ namespace wr::d3d12
 
 		CreateRenderTargetViews(render_window, device, width, height);
 		CreateDepthStencilBuffer(render_window, device, width, height);
-	
 	}
 
 	void Present(RenderWindow* render_window, Device* device)

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -91,14 +91,21 @@ namespace wr
 		// Execute
 		d3d12::End(m_direct_cmd_list);
 		d3d12::Execute(m_direct_queue, { m_direct_cmd_list }, m_fences[frame_idx]);
-		m_fences[frame_idx]->m_fence_value++;
-		d3d12::Signal(m_fences[frame_idx], m_direct_queue);
 	}
 
 	std::unique_ptr<Texture> D3D12RenderSystem::Render(std::shared_ptr<SceneGraph> const & scene_graph, FrameGraph & frame_graph)
 	{
+		if (m_requested_fullscreen_state.has_value())
+		{
+			WaitForAllPreviousWork();
+			m_render_window.value()->m_swap_chain->SetFullscreenState(m_requested_fullscreen_state.value(), nullptr);
+			Resize(m_window.value()->GetWidth(), m_window.value()->GetHeight());
+			m_requested_fullscreen_state = std::nullopt;
+		}
+
 		auto frame_idx = GetFrameIdx();
 		d3d12::WaitFor(m_fences[frame_idx]);
+
 
 		scene_graph->Update();
 
@@ -112,7 +119,6 @@ namespace wr
 		}
 
 		d3d12::Execute(m_direct_queue, n_cmd_lists, m_fences[frame_idx]);
-		d3d12::Signal(m_fences[frame_idx], m_direct_queue);
 
 		if (m_render_window.has_value())
 		{
@@ -122,11 +128,14 @@ namespace wr
 		return std::unique_ptr<Texture>();
 	}
 
-	void D3D12RenderSystem::Resize(std::int32_t width, std::int32_t height)
+	void D3D12RenderSystem::Resize(std::uint32_t width, std::uint32_t height)
 	{
+
+		d3d12::ResizeViewport(m_viewport, (int)width, (int)height);
+		
 		if (m_render_window.has_value())
 		{
-			d3d12::Resize(m_render_window.value(), m_device, width, height);
+			d3d12::Resize(m_render_window.value(), m_device, width, height, m_window.value()->IsFullscreen());
 		}
 	}
 
@@ -145,6 +154,7 @@ namespace wr
 		for (auto& fence : m_fences)
 		{
 			d3d12::WaitFor(fence);
+			Signal(fence, m_direct_queue);
 		}
 	}
 
@@ -207,10 +217,17 @@ namespace wr
 		}
 	}
 
-	void D3D12RenderSystem::ResizeRenderTarget(RenderTarget* render_target, std::uint32_t width, std::uint32_t height)
+	void D3D12RenderSystem::ResizeRenderTarget(RenderTarget** render_target, std::uint32_t width, std::uint32_t height)
 	{
-		auto n_render_target = static_cast<D3D12RenderTarget*>(render_target);
+		auto n_render_target = static_cast<D3D12RenderTarget*>(*render_target);
 		d3d12::Resize((d3d12::RenderTarget**)&n_render_target, m_device, width, height);
+
+		(*render_target) = n_render_target;
+	}
+
+	void D3D12RenderSystem::RequestFullscreenChange(bool fullscreen_state)
+	{
+		m_requested_fullscreen_state = fullscreen_state;
 	}
 
 	void D3D12RenderSystem::StartRenderTask(CommandList* cmd_list, std::pair<RenderTarget*, RenderTargetProperties> render_target)
@@ -360,8 +377,6 @@ namespace wr
 
 		// Execute
 		d3d12::Execute(m_direct_queue, { m_direct_cmd_list }, m_fences[frame_idx]);
-		m_fences[frame_idx]->m_fence_value++;
-		d3d12::Signal(m_fences[frame_idx], m_direct_queue);
 	}
 
 	void D3D12RenderSystem::Init_MeshNodes(std::vector<std::shared_ptr<MeshNode>>& nodes)

--- a/src/d3d12/d3d12_renderer.hpp
+++ b/src/d3d12/d3d12_renderer.hpp
@@ -52,7 +52,7 @@ namespace wr
 
 		void Init(std::optional<Window*> window) final;
 		std::unique_ptr<Texture> Render(std::shared_ptr<SceneGraph> const & scene_graph, FrameGraph & frame_graph) final;
-		void Resize(std::int32_t width, std::int32_t height) final;
+		void Resize(std::uint32_t width, std::uint32_t height) final;
 
 		std::shared_ptr<MaterialPool> CreateMaterialPool(std::size_t size_in_mb) final;
 		std::shared_ptr<ModelPool> CreateModelPool(std::size_t vertex_buffer_pool_size_in_mb, std::size_t index_buffer_pool_size_in_mb) final;
@@ -68,7 +68,8 @@ namespace wr
 		wr::CommandList* GetComputeCommandList(unsigned int num_allocators) final;
 		wr::CommandList* GetCopyCommandList(unsigned int num_allocators) final;
 		RenderTarget* GetRenderTarget(RenderTargetProperties properties) final;
-		void ResizeRenderTarget(RenderTarget* render_target, std::uint32_t width, std::uint32_t height) final;
+		void ResizeRenderTarget(RenderTarget** render_target, std::uint32_t width, std::uint32_t height) final;
+		void RequestFullscreenChange(bool fullscreen_state);
 
 		void StartRenderTask(CommandList* cmd_list, std::pair<RenderTarget*, RenderTargetProperties> render_target) final;
 		void StopRenderTask(CommandList* cmd_list, std::pair<RenderTarget*, RenderTargetProperties> render_target) final;
@@ -100,7 +101,8 @@ namespace wr
 		d3d12::Viewport m_viewport;
 		d3d12::CommandList* m_direct_cmd_list;
 		d3d12::StagingBuffer* m_fullscreen_quad_vb;
-
+	private:
+		std::optional<bool> m_requested_fullscreen_state;
 	};
 
 } /* wr */

--- a/src/d3d12/d3d12_settings.hpp
+++ b/src/d3d12/d3d12_settings.hpp
@@ -29,7 +29,7 @@ namespace wr::d3d12::settings
 	static const constexpr DXGI_ALPHA_MODE swapchain_alpha_mode = DXGI_ALPHA_MODE_UNSPECIFIED;
 	static const constexpr bool enable_gpu_timeout = false;
 	static const constexpr bool enable_debug_factory = true;
-	static const constexpr DebugLayer enable_debug_layer = DebugLayer::DISABLE;
+	static const constexpr DebugLayer enable_debug_layer = DebugLayer::ENABLE_WITH_GPU_VALIDATION;
 	static const constexpr char* default_shader_model = "5.0";
 	static const constexpr std::uint8_t num_back_buffers = 3;
 	static const constexpr std::uint32_t num_instances_per_batch = 768U;

--- a/src/d3d12/d3d12_settings.hpp
+++ b/src/d3d12/d3d12_settings.hpp
@@ -29,7 +29,7 @@ namespace wr::d3d12::settings
 	static const constexpr DXGI_ALPHA_MODE swapchain_alpha_mode = DXGI_ALPHA_MODE_UNSPECIFIED;
 	static const constexpr bool enable_gpu_timeout = false;
 	static const constexpr bool enable_debug_factory = true;
-	static const constexpr DebugLayer enable_debug_layer = DebugLayer::ENABLE_WITH_GPU_VALIDATION;
+	static const constexpr DebugLayer enable_debug_layer = DebugLayer::DISABLE;
 	static const constexpr char* default_shader_model = "5.0";
 	static const constexpr std::uint8_t num_back_buffers = 3;
 	static const constexpr std::uint32_t num_instances_per_batch = 768U;

--- a/src/d3d12/d3d12_viewport.cpp
+++ b/src/d3d12/d3d12_viewport.cpp
@@ -24,4 +24,15 @@ namespace wr::d3d12
 		return viewport;
 	}
 
+	void ResizeViewport(Viewport& viewport, int width, int height)
+	{
+		// Define viewport.
+		viewport.m_viewport.Width = static_cast<float>(width);
+		viewport.m_viewport.Height = static_cast<float>(height);
+
+		// Define scissor rect
+		viewport.m_scissor_rect.right = width;
+		viewport.m_scissor_rect.bottom = height;
+	}
+
 } /* wr::d3d12 */

--- a/src/render_tasks/d3d12_deferred_composition.hpp
+++ b/src/render_tasks/d3d12_deferred_composition.hpp
@@ -83,6 +83,12 @@ namespace wr
 			}
 		}
 
+
+		inline void ResizeDeferredTask(DeferredCompositionRenderTask_t & task, DeferredCompositionTaskData & data, std::uint32_t width, std::uint32_t height)
+		{
+			d3d12::Destroy(data.out_srv_heap);
+		}
+
 		inline void DestroyTestTask(DeferredCompositionRenderTask_t & task, DeferredCompositionTaskData& data)
 		{
 			d3d12::Destroy(data.out_srv_heap);
@@ -108,10 +114,9 @@ namespace wr
 				true,
 				true
 			},
-			[](RenderSystem & render_system, DeferredCompositionRenderTask_t & task, DeferredCompositionTaskData & data) { internal::SetupDeferredTask(render_system, task, data); },
+			[](RenderSystem & render_system, DeferredCompositionRenderTask_t & task, DeferredCompositionTaskData & data, bool) { internal::SetupDeferredTask(render_system, task, data); },
 			[](RenderSystem & render_system, DeferredCompositionRenderTask_t & task, SceneGraph & scene_graph, DeferredCompositionTaskData & data) { internal::ExecuteDeferredTask(render_system, task, scene_graph, data); },
-			[](RenderSystem & render_system, DeferredCompositionRenderTask_t & task, DeferredCompositionTaskData & data, std::uint32_t width, std::uint32_t height) {},
-			[](DeferredCompositionRenderTask_t & task, DeferredCompositionTaskData & data) { internal::DestroyTestTask(task, data); }
+			[](DeferredCompositionRenderTask_t & task, DeferredCompositionTaskData & data, bool) { internal::DestroyTestTask(task, data); }
 		);
 
 		return ptr;

--- a/src/render_tasks/d3d12_deferred_main.hpp
+++ b/src/render_tasks/d3d12_deferred_main.hpp
@@ -81,10 +81,9 @@ namespace wr
 				true,
 				true
 			},
-			[](RenderSystem & render_system, DeferredMainRenderTask_t & task, DeferredMainTaskData & data) { internal::SetupDeferredTask(render_system, task, data); },
+			[](RenderSystem & render_system, DeferredMainRenderTask_t & task, DeferredMainTaskData & data, bool) { internal::SetupDeferredTask(render_system, task, data); },
 			[](RenderSystem & render_system, DeferredMainRenderTask_t & task, SceneGraph & scene_graph, DeferredMainTaskData & data) { internal::ExecuteDeferredTask(render_system, task, scene_graph, data); },
-			[](RenderSystem & render_system, DeferredMainRenderTask_t & task, DeferredMainTaskData & data, std::uint32_t width, std::uint32_t height) {},
-			[](DeferredMainRenderTask_t & task, DeferredMainTaskData & data) { internal::DestroyTestTask(task, data); }
+			[](DeferredMainRenderTask_t & task, DeferredMainTaskData & data, bool) { internal::DestroyTestTask(task, data); }
 		);
 
 		return ptr;

--- a/src/render_tasks/d3d12_imgui_render_task.hpp
+++ b/src/render_tasks/d3d12_imgui_render_task.hpp
@@ -24,13 +24,19 @@ namespace wr
 	namespace internal
 	{
 
-		inline void SetupImGuiTask(RenderSystem & render_system, ImGuiRenderTask_t & task, ImGuiTaskData & data)
+		inline void SetupImGuiTask(RenderSystem & render_system, ImGuiRenderTask_t & task, ImGuiTaskData & data, bool resize)
 		{
 			auto& n_render_system = static_cast<D3D12RenderSystem&>(render_system);
 
 			if (!n_render_system.m_window.has_value())
 			{
 				LOGC("Tried using imgui without a window!");
+			}
+
+			if (resize)
+			{
+				ImGui_ImplDX12_CreateDeviceObjects();
+				return;
 			}
 
 			d3d12::desc::DescriptorHeapDesc heap_desc;
@@ -87,17 +93,18 @@ namespace wr
 			}
 		}
 
-		inline void ResizeImGuiTask(ImGuiRenderTask_t & task, ImGuiTaskData & data, std::uint32_t width, std::uint32_t height)
+		inline void DestroyImGuiTask(ImGuiRenderTask_t & task, ImGuiTaskData& data, bool resize)
 		{
-			ImGui_ImplDX12_InvalidateDeviceObjects();
-			ImGui_ImplDX12_CreateDeviceObjects();
-		}
-
-		inline void DestroyImGuiTask(ImGuiRenderTask_t & task, ImGuiTaskData& data)
-		{
-			ImGui_ImplDX12_Shutdown();
-			ImGui_ImplWin32_Shutdown();
-			ImGui::DestroyContext();
+			if (resize)
+			{
+				ImGui_ImplDX12_InvalidateDeviceObjects();
+			}
+			else
+			{
+				ImGui_ImplDX12_Shutdown();
+				ImGui_ImplWin32_Shutdown();
+				ImGui::DestroyContext();
+			}
 		}
 
 	} /* internal */
@@ -120,10 +127,9 @@ namespace wr
 				false,
 				false
 			},
-			[imgui_func](RenderSystem & render_system, ImGuiRenderTask_t & task, ImGuiTaskData & data) { data.in_imgui_func = imgui_func; internal::SetupImGuiTask(render_system, task, data); },
+			[imgui_func](RenderSystem & render_system, ImGuiRenderTask_t & task, ImGuiTaskData & data, bool resize) { data.in_imgui_func = imgui_func; internal::SetupImGuiTask(render_system, task, data, resize); },
 			[](RenderSystem & render_system, ImGuiRenderTask_t & task, SceneGraph & scene_graph, ImGuiTaskData & data) { internal::ExecuteImGuiTask(render_system, task, scene_graph, data); },
-			[](RenderSystem & render_system, ImGuiRenderTask_t & task, ImGuiTaskData & data, std::uint32_t width, std::uint32_t height) { internal::ResizeImGuiTask(task, data, width, height); },
-			[](ImGuiRenderTask_t & task, ImGuiTaskData & data) { internal::DestroyImGuiTask(task, data); }
+			[](ImGuiRenderTask_t & task, ImGuiTaskData & data, bool resize) { internal::DestroyImGuiTask(task, data, resize); }
 		);
 
 		return ptr;

--- a/src/render_tasks/d3d12_test_render_task.hpp
+++ b/src/render_tasks/d3d12_test_render_task.hpp
@@ -58,10 +58,9 @@ namespace wr
 				true,
 				true
 			},
-			[](RenderSystem & render_system, TestRenderTask_t & task, DeferredTaskData & data) { internal::SetupDeferredTask(render_system, task, data); },
+			[](RenderSystem & render_system, TestRenderTask_t & task, DeferredTaskData & data, bool) { internal::SetupDeferredTask(render_system, task, data); },
 			[](RenderSystem & render_system, TestRenderTask_t & task, SceneGraph & scene_graph, DeferredTaskData & data) { internal::ExecuteDeferredTask(render_system, task, scene_graph, data); },
-			[](RenderSystem & render_system, TestRenderTask_t & task, DeferredTaskData & data, std::uint32_t width, std::uint32_t height) {},
-			[](TestRenderTask_t & task, DeferredTaskData & data) { internal::DestroyTestTask(task, data); }
+			[](TestRenderTask_t & task, DeferredTaskData & data, bool) { internal::DestroyTestTask(task, data); }
 		);
 
 		return ptr;

--- a/src/renderer.hpp
+++ b/src/renderer.hpp
@@ -46,14 +46,14 @@ namespace wr
 		virtual CommandList* GetComputeCommandList(unsigned int num_allocators) = 0;
 		virtual CommandList* GetCopyCommandList(unsigned int num_allocators) = 0;
 		virtual RenderTarget* GetRenderTarget(RenderTargetProperties properties) = 0;
-		virtual void ResizeRenderTarget(RenderTarget* render_target, std::uint32_t width, std::uint32_t height) = 0;
+		virtual void ResizeRenderTarget(RenderTarget** render_target, std::uint32_t width, std::uint32_t height) = 0;
 
 		virtual void StartRenderTask(CommandList* cmd_list, std::pair<RenderTarget*, RenderTargetProperties> render_target) = 0;
 		virtual void StopRenderTask(CommandList* cmd_list, std::pair<RenderTarget*, RenderTargetProperties> render_target) = 0;
 
 		virtual void Init(std::optional<Window*> window) = 0;
 		virtual std::unique_ptr<Texture> Render(std::shared_ptr<SceneGraph> const & scene_graph, FrameGraph & frame_graph) = 0;
-		virtual void Resize(std::int32_t width, std::int32_t height) = 0;
+		virtual void Resize(std::uint32_t width, std::uint32_t height) = 0;
 		
 		std::optional<Window*> m_window;
 	};

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -138,6 +138,17 @@ namespace wr
 		return m_handle;
 	}
 
+	bool Window::IsFullscreen() const
+	{
+		RECT a, b;
+		GetWindowRect(m_handle, &a);
+		GetWindowRect(GetDesktopWindow(), &b);
+		return (a.left == b.left  &&
+			a.top == b.top   &&
+			a.right == b.right &&
+			a.bottom == b.bottom);
+	}
+
 	LRESULT CALLBACK Window::WindowProc(HWND handle, UINT msg, WPARAM w_param, LPARAM l_param)
 	{
 		extern LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -167,7 +178,7 @@ namespace wr
 
 			return 0;
 		case WM_SIZE:
-			if (w_param != SIZE_MINIMIZED)
+			if (w_param != SIZE_MINIMIZED && w_param != SIZE_RESTORED)
 			{
 				if (RECT rect; m_resize_callback && GetClientRect(handle, &rect))
 				{

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -178,7 +178,7 @@ namespace wr
 
 			return 0;
 		case WM_SIZE:
-			if (w_param != SIZE_MINIMIZED && w_param != SIZE_RESTORED)
+			if (w_param != SIZE_MINIMIZED)
 			{
 				if (RECT rect; m_resize_callback && GetClientRect(handle, &rect))
 				{

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -47,6 +47,8 @@ namespace wr
 		std::int32_t GetHeight() const;
 		/*! Returns the native window handle (HWND)*/
 		HWND GetWindowHandle() const;
+		/*! Checks whether the window is fullscreen */
+		bool IsFullscreen() const;
 
 	private:
 		/*! WindowProc that calls `WindowProc_Impl` */
@@ -55,6 +57,7 @@ namespace wr
 		LRESULT CALLBACK WindowProc_Impl(HWND, UINT, WPARAM, LPARAM);
 
 		KeyCallback m_key_callback;
+	public:
 		ResizeCallback m_resize_callback;
 
 		bool m_running;

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -57,7 +57,6 @@ namespace wr
 		LRESULT CALLBACK WindowProc_Impl(HWND, UINT, WPARAM, LPARAM);
 
 		KeyCallback m_key_callback;
-	public:
 		ResizeCallback m_resize_callback;
 
 		bool m_running;


### PR DESCRIPTION
I implemented resizing support and fixed a bug with signalling.

+ Swapchain now sets minimum frame latency.
+ Resizing is now properly implemented.
+ Fullscreen works as expected now.
+ The ability to request fullscreen mode. (Recommended over alt+enter)
+ Signal is no longer being called twice after every execute.
+ You can now (`d3d12::ResizeViewport`) resize the viewport.