### PR TITLE
Added DXR Device Initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if (MSVC)
 	target_compile_options(WispRenderer PRIVATE /W4 /permissive- /MP /Gm-)
 endif()
 
-target_include_directories(WispRenderer PUBLIC deps/fmt/include deps/assimp/include)
+target_include_directories(WispRenderer PUBLIC deps/fallback/Include deps/fmt/include deps/assimp/include)
 target_link_libraries(WispRenderer fmt assimp)
 
 # target_include_directories(WispRenderer PUBLIC deps/assimp/include)

--- a/src/d3d12/d3d12_settings.hpp
+++ b/src/d3d12/d3d12_settings.hpp
@@ -36,5 +36,6 @@ namespace wr::d3d12::settings
 	static const constexpr std::uint32_t num_lights = 21'845;					//1 MiB for StructuredBuffer<Light>
 	static const constexpr bool use_bundles = false;
 	static const constexpr bool use_exec_indirect = true;
+	static const constexpr bool force_dxr_fallback = false;
 
 } /* wr::d3d12::settings */

--- a/src/d3d12/d3d12_structs.hpp
+++ b/src/d3d12/d3d12_structs.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <optional>
 #include <array>
+#include <D3D12RaytracingFallback.h>
 
 #include "d3d12_enums.hpp"
 #include "d3d12_settings.hpp"
@@ -67,7 +68,7 @@ namespace wr::d3d12
 	struct Device
 	{
 		IDXGIAdapter4* m_adapter;
-		ID3D12Device4* m_native;
+		ID3D12Device5* m_native;
 		IDXGIFactory6* m_dxgi_factory;
 		D3D_FEATURE_LEVEL m_feature_level;
 
@@ -75,6 +76,11 @@ namespace wr::d3d12
 		DXGI_ADAPTER_DESC3 m_adapter_info;
 		ID3D12Debug1* m_debug_controller;
 		ID3D12InfoQueue* m_info_queue;
+
+		// Fallback
+		bool m_dxr_fallback_support;
+		bool m_dxr_support;
+		ID3D12RaytracingFallbackDevice* m_fallback_native;
 	};
 
 	struct CommandQueue

--- a/src/imgui_tools.cpp
+++ b/src/imgui_tools.cpp
@@ -121,9 +121,12 @@ namespace wr::imgui::window
 			{
 				std::wstring wdesc(dx_info.Description);
 				std::string desc(wdesc.begin(), wdesc.end());
+				auto device = render_system.m_device;
 
-				ImGui::Text("Feature Level: %s", internal::FeatureLevelToStr(render_system.m_device->m_feature_level).c_str());
 				ImGui::Text("Description: %s", desc.c_str());
+				ImGui::Text("Feature Level: %s", internal::FeatureLevelToStr(device->m_feature_level).c_str());
+				ImGui::Text("DXR Support: %s", internal::BooltoStr(device->m_dxr_support).c_str());
+				ImGui::Text("DXR Fallback Support: %s", internal::BooltoStr(device->m_dxr_fallback_support).c_str());
 				ImGui::Text("Vendor ID: %i", dx_info.VendorId);
 				ImGui::Text("Device ID: %i", dx_info.DeviceId);
 				ImGui::Text("Subsystem ID: %i", dx_info.SubSysId);


### PR DESCRIPTION
* WispRenderer now includes the fallback layer properly.
* The Device now also contains a fallback DXR struct and is now using Device5 instead of 4.