### PR TITLE
Windowless rendering

### DIFF
--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -39,20 +39,6 @@ int WispEntry()
 	};
 
 	render_system = std::make_unique<wr::D3D12RenderSystem>();
-	auto window = std::make_unique<wr::Window>(GetModuleHandleA(nullptr), "D3D12 Test App", 1280, 720);
-
-	window->SetKeyCallback([](int key, int action, int mods)
-	{
-		if (action == WM_KEYUP && key == 0xC0)
-		{
-			engine::open_console = !engine::open_console;
-			engine::debug_console.EmptyInput();
-		}
-		if (action == WM_KEYUP && key == VK_F1)
-		{
-			engine::show_imgui = !engine::show_imgui;
-		}
-	});
 
 	wr::ModelLoader* assimp_model_loader = new wr::AssimpModelLoader();
 
@@ -62,7 +48,7 @@ int WispEntry()
 
 	scene_graph = std::make_shared<wr::SceneGraph>(render_system.get());
 
-	SCENE::CreateScene(scene_graph.get(), window.get());
+	SCENE::CreateScene(scene_graph.get());
 
 	render_system->InitSceneGraph(*scene_graph.get());
 
@@ -81,17 +67,8 @@ int WispEntry()
 	frame_graph.AddTask(wr::GetImGuiTask(&RenderEditor));
 	frame_graph.Setup(*render_system);
 
-	window->SetResizeCallback([&](std::uint32_t width, std::uint32_t height)
+	while (true)
 	{
-		render_system->WaitForAllPreviousWork();
-		frame_graph.Resize(*render_system.get(), width, height);
-		render_system->Resize(width, height);
-	});
-
-	while (window->IsRunning())
-	{
-		window->PollEvents();
-
 		SCENE::UpdateScene();
 
 		auto texture = render_system->Render(scene_graph, frame_graph);

--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include "wisp.hpp"
 #include "render_tasks/d3d12_test_render_task.hpp"
-#include "render_tasks/d3d12_imgui_render_task.hpp"
 #include "render_tasks/d3d12_deferred_main.hpp"
 #include "render_tasks/d3d12_deferred_composition.hpp"
 #include "render_tasks/d3d12_deferred_render_target_copy.hpp"
@@ -27,11 +26,6 @@ std::shared_ptr<wr::TexturePool> texture_pool;
 
 constexpr unsigned int RENDER_TARGET_WIDTH = 1280;
 constexpr unsigned int RENDER_TARGET_HEIGHT = 720;
-
-void RenderEditor()
-{
-	engine::RenderEngine(render_system.get(), scene_graph.get());
-}
 
 int WispEntry()
 {
@@ -67,7 +61,6 @@ int WispEntry()
 		frame_graph.AddTask(wr::GetRaytracingTask(RENDER_TARGET_WIDTH, RENDER_TARGET_HEIGHT));
 		frame_graph.AddTask(wr::GetRenderTargetCopyTask<wr::RaytracingData>(RENDER_TARGET_WIDTH, RENDER_TARGET_HEIGHT));
 	}
-	frame_graph.AddTask(wr::GetImGuiTask(&RenderEditor, RENDER_TARGET_WIDTH, RENDER_TARGET_HEIGHT));
 	frame_graph.Setup(*render_system);
 
 	while (true)

--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -25,6 +25,9 @@ std::shared_ptr<wr::SceneGraph> scene_graph;
 
 std::shared_ptr<wr::TexturePool> texture_pool;
 
+constexpr unsigned int RENDER_TARGET_WIDTH = 1280;
+constexpr unsigned int RENDER_TARGET_HEIGHT = 720;
+
 void RenderEditor()
 {
 	engine::RenderEngine(render_system.get(), scene_graph.get());
@@ -55,16 +58,16 @@ int WispEntry()
 	wr::FrameGraph frame_graph;
 	if (do_raytracing)
 	{
-		frame_graph.AddTask(wr::GetDeferredMainTask());
-		frame_graph.AddTask(wr::GetDeferredCompositionTask());
-		frame_graph.AddTask(wr::GetRenderTargetCopyTask<wr::DeferredCompositionTaskData>());
+		frame_graph.AddTask(wr::GetDeferredMainTask(RENDER_TARGET_WIDTH, RENDER_TARGET_HEIGHT));
+		frame_graph.AddTask(wr::GetDeferredCompositionTask(RENDER_TARGET_WIDTH, RENDER_TARGET_HEIGHT));
+		frame_graph.AddTask(wr::GetRenderTargetCopyTask<wr::DeferredCompositionTaskData>(RENDER_TARGET_WIDTH, RENDER_TARGET_HEIGHT));
 	}
 	else
 	{
-		frame_graph.AddTask(wr::GetRaytracingTask());
-		frame_graph.AddTask(wr::GetRenderTargetCopyTask<wr::RaytracingData>());
+		frame_graph.AddTask(wr::GetRaytracingTask(RENDER_TARGET_WIDTH, RENDER_TARGET_HEIGHT));
+		frame_graph.AddTask(wr::GetRenderTargetCopyTask<wr::RaytracingData>(RENDER_TARGET_WIDTH, RENDER_TARGET_HEIGHT));
 	}
-	frame_graph.AddTask(wr::GetImGuiTask(&RenderEditor));
+	frame_graph.AddTask(wr::GetImGuiTask(&RenderEditor, RENDER_TARGET_WIDTH, RENDER_TARGET_HEIGHT));
 	frame_graph.Setup(*render_system);
 
 	while (true)

--- a/demo/scene_viknell.hpp
+++ b/demo/scene_viknell.hpp
@@ -57,7 +57,5 @@ namespace viknell_scene
 
 	void UpdateScene()
 	{
-
-		t += 10.f * ImGui::GetIO().DeltaTime;
 	}
 } /* cube_scene */

--- a/demo/scene_viknell.hpp
+++ b/demo/scene_viknell.hpp
@@ -57,5 +57,6 @@ namespace viknell_scene
 
 	void UpdateScene()
 	{
+		t += 10.f * ImGui::GetIO().DeltaTime;
 	}
 } /* cube_scene */

--- a/demo/scene_viknell.hpp
+++ b/demo/scene_viknell.hpp
@@ -14,9 +14,9 @@ namespace viknell_scene
 	static std::shared_ptr<wr::LightNode> directional_light_node;
 	static float t = 0;
 
-	void CreateScene(wr::SceneGraph* scene_graph, wr::Window* window)
+	void CreateScene(wr::SceneGraph* scene_graph, float aspect_ratio = 16.0f / 9.0f)
 	{
-		camera = scene_graph->CreateChild<wr::CameraNode>(nullptr, 90.f, (float)window->GetWidth() / (float)window->GetHeight());
+		camera = scene_graph->CreateChild<wr::CameraNode>(nullptr, 90.f, aspect_ratio);
 		camera->SetPosition({ 0, 0, -1 });
 		
 		// Geometry

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -50,7 +50,11 @@ namespace wr
 		d3d12::Destroy(m_direct_queue);
 		d3d12::Destroy(m_copy_queue);
 		d3d12::Destroy(m_compute_queue);
-		if (m_render_window.has_value()) d3d12::Destroy(m_render_window.value());
+
+		if (m_render_window.has_value())
+		{
+			d3d12::Destroy(m_render_window.value());
+		}
 	}
 
 	void D3D12RenderSystem::Init(std::optional<Window*> window)

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -67,7 +67,13 @@ namespace wr
 
 		if (window.has_value())
 		{
+			// Windowed rendering mode
 			m_render_window = d3d12::CreateRenderWindow(m_device, window.value()->GetWindowHandle(), m_direct_queue, d3d12::settings::num_back_buffers);
+		}
+		else
+		{
+			// Window-less rendering mode
+			CoInitializeEx(NULL, COINIT_MULTITHREADED); // WIC requires the COM library to be initialized
 		}
 
 		PrepareShaderRegistry();

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -36,14 +36,14 @@ namespace wr
 
 	D3D12RenderSystem::~D3D12RenderSystem()
 	{
-		for (int i = 0; i < m_structured_buffer_pools.size(); ++i)
+		for (auto& structured_buffer_pool : m_structured_buffer_pools)
 		{
-			m_structured_buffer_pools[i].reset();
+			structured_buffer_pool.reset();
 		}
 		
-		for (int i = 0; i < m_model_pools.size(); ++i)
+		for (auto& model_pool : m_model_pools)
 		{
-			m_model_pools[i].reset();
+			model_pool.reset();
 		}
 
 		d3d12::Destroy(m_device);
@@ -77,7 +77,7 @@ namespace wr
 		else
 		{
 			// Window-less rendering mode
-			CoInitializeEx(NULL, COINIT_MULTITHREADED); // WIC requires the COM library to be initialized
+			CoInitializeEx(nullptr, COINIT_MULTITHREADED); // WIC requires the COM library to be initialized
 		}
 
 		PrepareShaderRegistry();
@@ -97,11 +97,11 @@ namespace wr
 
 		// Create screen quad
 		m_fullscreen_quad_vb = d3d12::CreateStagingBuffer(m_device, (void*)temp::quad_vertices, 4 * sizeof(Vertex2D), sizeof(Vertex2D), ResourceState::VERTEX_AND_CONSTANT_BUFFER);
-		SetName(m_fullscreen_quad_vb, L"Fullscreen quad vertex buffer");
+		SetName(m_fullscreen_quad_vb, L"Full screen quad vertex buffer");
 
 		// Create Command List
 		m_direct_cmd_list = d3d12::CreateCommandList(m_device, d3d12::settings::num_back_buffers, CmdListType::CMD_LIST_DIRECT);
-		SetName(m_direct_cmd_list, L"Defauld DX12 Command List");
+		SetName(m_direct_cmd_list, L"Default DX12 Command List");
 
 		//TEMP
 		//Create Rendering Descriptor Heap
@@ -112,10 +112,10 @@ namespace wr
 
 		m_rendering_heap = d3d12::CreateDescriptorHeap(m_device, heap_desc);
 
-		// Raytracing cb pool
+		// Ray tracing cb pool
 		m_raytracing_cb_pool = CreateConstantBufferPool(1);
 
-		// Material raytracing sb pool
+		// Material ray tracing sb pool
 		size_t rt_mat_align_size = (sizeof(temp::RayTracingMaterial_CBData) * d3d12::settings::num_max_rt_materials) * d3d12::settings::num_back_buffers;
 		m_raytracing_material_sb_pool = CreateStructuredBufferPool(1);
 
@@ -148,8 +148,8 @@ namespace wr
 			auto root_signature = static_cast<D3D12RootSignature*>(RootSignatureRegistry::Get().Find(root_signatures::basic));
 			m_cmd_signature = d3d12::CreateCommandSignature(m_device, root_signature->m_native, arg_descs, sizeof(temp::IndirectCommand));
 			m_cmd_signature_indexed = d3d12::CreateCommandSignature(m_device, root_signature->m_native, indexed_arg_descs, sizeof(temp::IndirectCommandIndexed));
-			SetName(m_cmd_signature, L"Defauld DX12 Command Signature");
-			SetName(m_cmd_signature_indexed, L"Defauld DX12 Command Signature Indexed");
+			SetName(m_cmd_signature, L"Default DX12 Command Signature");
+			SetName(m_cmd_signature_indexed, L"Default DX12 Command Signature Indexed");
 		}
 
 		// Execute
@@ -306,15 +306,15 @@ namespace wr
 			if (properties.m_width.has_value() || properties.m_height.has_value())
 			{
 				auto retval = d3d12::CreateRenderTarget(m_device, properties.m_width.value(), properties.m_height.value(), desc);
-				for (auto i = 0; i < retval->m_render_targets.size(); i++)
-					retval->m_render_targets[i]->SetName(L"Main Deferred RT");
+				for (auto& render_target : retval->m_render_targets)
+					render_target->SetName(L"Main Deferred RT");
 				return retval;
 			}
 			else if (m_window.has_value())
 			{
 				auto retval = d3d12::CreateRenderTarget(m_device, m_window.value()->GetWidth(), m_window.value()->GetHeight(), desc);
-				for (auto i = 0; i < retval->m_render_targets.size(); i++)
-					retval->m_render_targets[i]->SetName(L"Main Deferred RT");
+				for (auto& render_target : retval->m_render_targets)
+					render_target->SetName(L"Main Deferred RT");
 				return retval;
 			}
 			else
@@ -803,7 +803,7 @@ namespace wr
 						command.draw_arguments.InstanceCount = batch.num_instances;
 						command.draw_arguments.StartIndexLocation = n_mesh->m_index_staging_buffer_offset;
 						command.draw_arguments.StartInstanceLocation = 0;
-						command.draw_arguments.BaseVertexLocation = n_mesh->m_vertex_staging_buffer_offset; // 1170.sometghing fuck me
+						command.draw_arguments.BaseVertexLocation = n_mesh->m_vertex_staging_buffer_offset; // 1170
 						indexed_commands.push_back(command);
 					}
 					else

--- a/src/render_tasks/d3d12_deferred_composition.hpp
+++ b/src/render_tasks/d3d12_deferred_composition.hpp
@@ -159,14 +159,16 @@ namespace wr
 	} /* internal */
 
 
-	//! Used to create a new defferred task.
-	[[nodiscard]] inline std::unique_ptr<DeferredCompositionRenderTask_t> GetDeferredCompositionTask()
+	//! Used to create a new deferred task.
+	[[nodiscard]] inline std::unique_ptr<DeferredCompositionRenderTask_t> GetDeferredCompositionTask(
+		std::optional<unsigned int> render_target_width,
+		std::optional<unsigned int> render_target_height)
 	{
 		auto ptr = std::make_unique<DeferredCompositionRenderTask_t>(nullptr, "Deferred Render Task", RenderTaskType::COMPUTE, true,
 			RenderTargetProperties{
 				false,
-				std::nullopt,
-				std::nullopt,
+				render_target_width,
+				render_target_height,
 				ResourceState::UNORDERED_ACCESS,
 				ResourceState::COPY_SOURCE,
 				false,

--- a/src/render_tasks/d3d12_deferred_main.hpp
+++ b/src/render_tasks/d3d12_deferred_main.hpp
@@ -68,14 +68,16 @@ namespace wr
 	} /* internal */
 	
 
-	//! Used to create a new defferred task.
-	[[nodiscard]] inline std::unique_ptr<DeferredMainRenderTask_t> GetDeferredMainTask()
+	//! Used to create a new deferred task.
+	[[nodiscard]] inline std::unique_ptr<DeferredMainRenderTask_t> GetDeferredMainTask(
+		std::optional<unsigned int> render_target_width,
+		std::optional<unsigned int> render_target_height)
 	{
 		auto ptr = std::make_unique<DeferredMainRenderTask_t>(nullptr, "Deferred Render Task", RenderTaskType::DIRECT, true,
 			RenderTargetProperties{
 				false,
-				std::nullopt,
-				std::nullopt,
+				render_target_width,
+				render_target_height,
 				ResourceState::RENDER_TARGET,
 				ResourceState::NON_PIXEL_SHADER_RESOURCE,
 				true,

--- a/src/render_tasks/d3d12_deferred_render_target_copy.hpp
+++ b/src/render_tasks/d3d12_deferred_render_target_copy.hpp
@@ -24,7 +24,7 @@ namespace wr
 	namespace internal
 	{
 		template<typename T>
-		inline void SetupCopyTask(RenderSystem & render_system, DeferredRenderTargetCopyRenderTask_t & task, DeferredRenderTargetCopyTaskData & data)
+		inline void SetupCopyTask(RenderSystem& render_system, DeferredRenderTargetCopyRenderTask_t& task, DeferredRenderTargetCopyTaskData& data)
 		{
 			auto& n_render_system = static_cast<D3D12RenderSystem&>(render_system);
 			auto* fg = task.GetFrameGraph();
@@ -32,7 +32,7 @@ namespace wr
 			data.out_rt = static_cast<d3d12::RenderTarget*>(fg->GetData<T>().m_render_target);
 		}
 
-		inline void ExecuteCopyTask(RenderSystem & render_system, DeferredRenderTargetCopyRenderTask_t& task, SceneGraph & scene_graph, DeferredRenderTargetCopyTaskData& data)
+		inline void ExecuteCopyTask(RenderSystem& render_system, DeferredRenderTargetCopyRenderTask_t& task, SceneGraph& scene_graph, DeferredRenderTargetCopyTaskData& data)
 		{
 			auto& n_render_system = static_cast<D3D12RenderSystem&>(render_system);
 

--- a/src/render_tasks/d3d12_deferred_render_target_copy.hpp
+++ b/src/render_tasks/d3d12_deferred_render_target_copy.hpp
@@ -69,13 +69,15 @@ namespace wr
 
 	//! Used to create a new deferred task.
 	template<typename T>
-	[[nodiscard]] inline std::unique_ptr<DeferredRenderTargetCopyRenderTask_t> GetRenderTargetCopyTask()
+	[[nodiscard]] inline std::unique_ptr<DeferredRenderTargetCopyRenderTask_t> GetRenderTargetCopyTask(
+		std::optional<unsigned int> render_target_width,
+		std::optional<unsigned int> render_target_height)
 	{
 		auto ptr = std::make_unique<DeferredRenderTargetCopyRenderTask_t>(nullptr, "Copy RT Render Task", RenderTaskType::COPY, true,
 			RenderTargetProperties{
 				true,
-				std::nullopt,
-				std::nullopt,
+				render_target_width,
+				render_target_height,
 				ResourceState::COPY_DEST,
 				ResourceState::PRESENT,
 				false,

--- a/src/render_tasks/d3d12_deferred_render_target_copy.hpp
+++ b/src/render_tasks/d3d12_deferred_render_target_copy.hpp
@@ -67,17 +67,15 @@ namespace wr
 	} /* internal */
 
 
-	//! Used to create a new deferred task.
+	//! Used to create a new deferred task that depends on the window being available
 	template<typename T>
-	[[nodiscard]] inline std::unique_ptr<DeferredRenderTargetCopyRenderTask_t> GetRenderTargetCopyTask(
-		std::optional<unsigned int> render_target_width,
-		std::optional<unsigned int> render_target_height)
+	[[nodiscard]] inline std::unique_ptr<DeferredRenderTargetCopyRenderTask_t> GetRenderTargetCopyTask()
 	{
 		auto ptr = std::make_unique<DeferredRenderTargetCopyRenderTask_t>(nullptr, "Copy RT Render Task", RenderTaskType::COPY, true,
 			RenderTargetProperties{
 				true,
-				render_target_width,
-				render_target_height,
+				std::nullopt,
+				std::nullopt,
 				ResourceState::COPY_DEST,
 				ResourceState::PRESENT,
 				false,
@@ -87,9 +85,37 @@ namespace wr
 				true,
 				true
 			},
-			[](RenderSystem & render_system, DeferredRenderTargetCopyRenderTask_t & task, DeferredRenderTargetCopyTaskData& data, bool) { internal::SetupCopyTask<T>(render_system, task, data); },
-			[](RenderSystem & render_system, DeferredRenderTargetCopyRenderTask_t& task, SceneGraph & scene_graph, DeferredRenderTargetCopyTaskData& data) { internal::ExecuteCopyTask(render_system, task, scene_graph, data); },
-			[](DeferredRenderTargetCopyRenderTask_t & task, DeferredRenderTargetCopyTaskData& data, bool) { internal::DestroyCopyTask(task, data); }
+			[](RenderSystem& render_system, DeferredRenderTargetCopyRenderTask_t& task, DeferredRenderTargetCopyTaskData& data, bool) { internal::SetupCopyTask<T>(render_system, task, data); },
+			[](RenderSystem& render_system, DeferredRenderTargetCopyRenderTask_t& task, SceneGraph& scene_graph, DeferredRenderTargetCopyTaskData& data) { internal::ExecuteCopyTask(render_system, task, scene_graph, data); },
+			[](DeferredRenderTargetCopyRenderTask_t& task, DeferredRenderTargetCopyTaskData& data, bool) { internal::DestroyCopyTask(task, data); }
+		);
+
+		return ptr;
+	}
+
+	//! Used to create a new deferred task that does not depend the window being available
+	template<typename T>
+	[[nodiscard]] inline std::unique_ptr<DeferredRenderTargetCopyRenderTask_t> GetRenderTargetCopyTask(
+		unsigned int render_target_width,
+		unsigned int render_target_height)
+	{
+		auto ptr = std::make_unique<DeferredRenderTargetCopyRenderTask_t>(nullptr, "Copy RT Render Task", RenderTaskType::COPY, true,
+			RenderTargetProperties{
+				false,
+				render_target_width,
+				render_target_height,
+				ResourceState::COPY_DEST,
+				ResourceState::COPY_SOURCE,
+				false,
+				Format::UNKNOWN,
+				{ Format::R8G8B8A8_UNORM },
+				1,
+				true,
+				true
+			},
+			[](RenderSystem& render_system, DeferredRenderTargetCopyRenderTask_t& task, DeferredRenderTargetCopyTaskData& data, bool) { internal::SetupCopyTask<T>(render_system, task, data); },
+			[](RenderSystem& render_system, DeferredRenderTargetCopyRenderTask_t& task, SceneGraph& scene_graph, DeferredRenderTargetCopyTaskData& data) { internal::ExecuteCopyTask(render_system, task, scene_graph, data); },
+			[](DeferredRenderTargetCopyRenderTask_t& task, DeferredRenderTargetCopyTaskData& data, bool) { internal::DestroyCopyTask(task, data); }
 		);
 
 		return ptr;

--- a/src/render_tasks/d3d12_imgui_render_task.hpp
+++ b/src/render_tasks/d3d12_imgui_render_task.hpp
@@ -119,16 +119,13 @@ namespace wr
 	
 
 	//! Used to create a new deferred task.
-	[[nodiscard]] inline std::unique_ptr<ImGuiRenderTask_t> GetImGuiTask(
-		std::function<void()> imgui_func,
-		std::optional<unsigned int> render_target_width,
-		std::optional<unsigned int> render_target_height)
+	[[nodiscard]] inline std::unique_ptr<ImGuiRenderTask_t> GetImGuiTask(std::function<void()> imgui_func)
 	{
 		auto ptr = std::make_unique<ImGuiRenderTask_t>(nullptr, "ImGui Render Task", RenderTaskType::DIRECT, false,
 			RenderTargetProperties {
 				true,
-				render_target_width,
-				render_target_height,
+				std::nullopt,
+				std::nullopt,
 				std::nullopt,
 				std::nullopt,
 				false,

--- a/src/render_tasks/d3d12_imgui_render_task.hpp
+++ b/src/render_tasks/d3d12_imgui_render_task.hpp
@@ -118,14 +118,17 @@ namespace wr
 	} /* internal */
 	
 
-	//! Used to create a new defferred task.
-	[[nodiscard]] inline std::unique_ptr<ImGuiRenderTask_t> GetImGuiTask(std::function<void()> imgui_func)
+	//! Used to create a new deferred task.
+	[[nodiscard]] inline std::unique_ptr<ImGuiRenderTask_t> GetImGuiTask(
+		std::function<void()> imgui_func,
+		std::optional<unsigned int> render_target_width,
+		std::optional<unsigned int> render_target_height)
 	{
 		auto ptr = std::make_unique<ImGuiRenderTask_t>(nullptr, "ImGui Render Task", RenderTaskType::DIRECT, false,
 			RenderTargetProperties {
 				true,
-				std::nullopt,
-				std::nullopt,
+				render_target_width,
+				render_target_height,
 				std::nullopt,
 				std::nullopt,
 				false,

--- a/src/render_tasks/d3d12_raytracing_task.hpp
+++ b/src/render_tasks/d3d12_raytracing_task.hpp
@@ -343,14 +343,16 @@ namespace wr
 	} /* internal */
 
 
-	//! Used to create a new defferred task.
-	[[nodiscard]] inline std::unique_ptr<RaytracingTask> GetRaytracingTask()
+	//! Used to create a new deferred task.
+	[[nodiscard]] inline std::unique_ptr<RaytracingTask> GetRaytracingTask(
+		std::optional<unsigned int> render_target_width,
+		std::optional<unsigned int> render_target_height)
 	{
 		auto ptr = std::make_unique<RaytracingTask>(nullptr, "Deferred Render Task", RenderTaskType::COMPUTE, true,
 			RenderTargetProperties{
 				false,
-				std::nullopt,
-				std::nullopt,
+				render_target_width,
+				render_target_height,
 				ResourceState::UNORDERED_ACCESS,
 				ResourceState::COPY_SOURCE,
 				false,

--- a/src/render_tasks/d3d12_test_render_task.hpp
+++ b/src/render_tasks/d3d12_test_render_task.hpp
@@ -40,14 +40,16 @@ namespace wr
 	} /* internal */
 	
 
-	//! Used to create a new defferred task.
-	[[nodiscard]] inline std::unique_ptr<TestRenderTask_t> GetTestTask()
+	//! Used to create a new deferred task.
+	[[nodiscard]] inline std::unique_ptr<TestRenderTask_t> GetTestTask(
+		std::optional<unsigned int> render_target_width,
+		std::optional<unsigned int> render_target_height)
 	{
 		auto ptr = std::make_unique<TestRenderTask_t>(nullptr, "Deferred Render Task", RenderTaskType::DIRECT, true,
 			RenderTargetProperties{
 				true,
-				std::nullopt,
-				std::nullopt,
+				render_target_width,
+				render_target_height,
 				std::nullopt,
 				std::nullopt,
 				true,


### PR DESCRIPTION
**Description**
- Most render tasks now have `std::optional<unsigned int>` that allows the user to pass the width and height of the render target without the need for a window.
- Corrected '&'-sign placement in a few files.
- When no window is specified, the COM library is initialized manually.

**Issues**
No relevant issues.

**Possible conflicts**
- Existing render passes might need to start using `std::nullopt` for the optional width and height arguments.