### PR TITLE
Depth buffer CPU copy

### DIFF
--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -143,6 +143,17 @@ int WispEntry()
 		SCENE::UpdateScene();
 
 		auto texture = render_system->Render(scene_graph, *fg_manager::Get());
+
+		// Example usage of the render function output:
+		if (texture.pixel_data != std::nullopt)
+		{
+			// Use pixel data here
+		}
+
+		if (texture.depth_data != std::nullopt)
+		{
+			// Use depth data here
+		}
 	}
 
 	delete assimp_model_loader;

--- a/demo/demo_frame_graphs.hpp
+++ b/demo/demo_frame_graphs.hpp
@@ -7,7 +7,6 @@
 #include "render_tasks/d3d12_deferred_render_target_copy.hpp"
 #include "render_tasks/d3d12_raytracing_task.hpp"
 #include "render_tasks/d3d12_accumulation.hpp"
-#include "render_tasks/d3d12_pixel_data_readback.hpp"
 #include "render_tasks/d3d12_build_acceleration_structures.hpp"
 
 namespace fg_manager

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -145,7 +145,7 @@ namespace wr
 		m_buffer_frame_graph_uids.resize(d3d12::settings::num_back_buffers);
 	}
 
-	CPUTexture D3D12RenderSystem::Render(std::shared_ptr<SceneGraph> const & scene_graph, FrameGraph & frame_graph)
+	CPUTextures D3D12RenderSystem::Render(std::shared_ptr<SceneGraph> const & scene_graph, FrameGraph & frame_graph)
 	{
 
  		if (m_requested_fullscreen_state.has_value())
@@ -230,14 +230,9 @@ namespace wr
 
 		//Signal end of frame to the texture pool so that stale descriptors can be freed.
 		m_texture_pool->EndOfFrame();
-		// Optional CPU-visible copy of the render target pixel data
-		const auto cpu_output_texture = frame_graph.GetOutputTexture();
 
-		// If no pixel data is available, return null, else, return GPU pixel data
-		if (cpu_output_texture.has_value())
-			return cpu_output_texture.value();
-		else
-			return CPUTexture();
+		// Optional CPU-visible copy of the render target pixel and/or depth data
+		return frame_graph.GetOutputTexture();
 	}
 
 	void D3D12RenderSystem::Resize(std::uint32_t width, std::uint32_t height)

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -512,7 +512,7 @@ namespace wr
 			}
 			else
 			{
-				LOGC("Failed to load shader. compiler error: {}", std::get<std::string>(shader_error));
+				LOGC(std::get<std::string>(shader_error));
 			}
 		}
 	}

--- a/src/d3d12/d3d12_renderer.hpp
+++ b/src/d3d12/d3d12_renderer.hpp
@@ -90,7 +90,7 @@ namespace wr
 		~D3D12RenderSystem() final;
 
 		void Init(std::optional<Window*> window) final;
-		CPUTexture Render(std::shared_ptr<SceneGraph> const & scene_graph, FrameGraph & frame_graph) final;
+		CPUTextures Render(std::shared_ptr<SceneGraph> const & scene_graph, FrameGraph & frame_graph) final;
 		void Resize(std::uint32_t width, std::uint32_t height) final;
 
 		std::shared_ptr<TexturePool> CreateTexturePool(std::size_t size_in_mb, std::size_t num_of_textures) final;

--- a/src/render_tasks/d3d12_pixel_data_readback.hpp
+++ b/src/render_tasks/d3d12_pixel_data_readback.hpp
@@ -134,7 +134,7 @@ namespace wr
 			internal::DestroyReadBackTask(frame_graph, handle);
 		};
 
-		readback_task_description.m_name = std::string(std::string("Render Target (") + std::string(typeid(T).name()) + std::string(") read-back task")).c_str();
+		readback_task_description.m_name = std::string(std::string("Render target pixel data (") + std::string(typeid(T).name()) + std::string(") read-back task")).c_str();
 		readback_task_description.m_properties = rt_properties;
 		readback_task_description.m_type = RenderTaskType::COPY;
 		readback_task_description.m_allow_multithreading = false;

--- a/src/render_tasks/d3d12_pixel_data_readback.hpp
+++ b/src/render_tasks/d3d12_pixel_data_readback.hpp
@@ -82,7 +82,7 @@ namespace wr
 			command_list->m_native->CopyTextureRegion(&destination, 0, 0, 0, &source, nullptr);
 
 			// Update the frame graph output texture (allows the renderer to access this data)
-			frame_graph.SetOutputTexture(data.cpu_texture_output);
+			frame_graph.SetOutputTexture(data.cpu_texture_output, CPUTextureType::PIXEL_DATA);
 		}
 		
 		inline void DestroyReadBackTask(FrameGraph& fg, RenderTaskHandle handle)

--- a/src/renderer.hpp
+++ b/src/renderer.hpp
@@ -11,6 +11,7 @@ namespace wr
 
 	struct TextureHandle;
 	struct Model;
+	struct CPUTextures;
 
 	class Window;
 	class SceneGraph;
@@ -20,7 +21,6 @@ namespace wr
 	class ConstantBufferPool;
 	class StructuredBufferPool;
 	class FrameGraph;
-	class CPUTexture;
 
 	class RenderSystem
 	{
@@ -61,7 +61,7 @@ namespace wr
 		virtual void StopCopyTask(CommandList* cmd_list, std::pair<RenderTarget*, RenderTargetProperties> render_target) = 0;
 
 		virtual void Init(std::optional<Window*> window) = 0;
-		virtual CPUTexture Render(std::shared_ptr<SceneGraph> const & scene_graph, FrameGraph & frame_graph) = 0;
+		virtual CPUTextures Render(std::shared_ptr<SceneGraph> const & scene_graph, FrameGraph & frame_graph) = 0;
 		virtual void Resize(std::uint32_t width, std::uint32_t height) = 0;
 		
 		std::optional<Window*> m_window;


### PR DESCRIPTION
**Description**
Implemented a new render pass that writes the depth buffer to a CPU visible buffer. The frame graph has been changed to allow for more textures to be written to the CPU (instead of only 1).

**Issues**
- None.

**Possible conflicts**
If you made changes to the frame graph, you will have to do a merge and test the new changes. This feature should not break anything, though... It is fairly self-contained.
