### PR TITLE
Fix light crash and allow multiple samplers

### DIFF
--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -872,7 +872,7 @@ namespace wr
 			offset_end = i;
 		}
 
-		if (!should_update)
+		if (!should_update && !(offset_end == offset_start && offset_start == 0))
 			return;
 
 		StructuredBufferHandle* structured_buffer = scene_graph.GetLightBuffer();

--- a/src/d3d12/d3d12_root_signature.cpp
+++ b/src/d3d12/d3d12_root_signature.cpp
@@ -39,19 +39,19 @@ namespace wr::d3d12
 		{
 			auto sampler_info = create_info.m_samplers[i];
 
-			samplers[0].Filter = (D3D12_FILTER)sampler_info.m_filter;
-			samplers[0].AddressU = (D3D12_TEXTURE_ADDRESS_MODE)sampler_info.m_address_mode;
-			samplers[0].AddressV = (D3D12_TEXTURE_ADDRESS_MODE)sampler_info.m_address_mode;
-			samplers[0].AddressW = (D3D12_TEXTURE_ADDRESS_MODE)sampler_info.m_address_mode;
-			samplers[0].MipLODBias = 0;
-			samplers[0].MaxAnisotropy = 0;
-			samplers[0].ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-			samplers[0].BorderColor = (D3D12_STATIC_BORDER_COLOR)sampler_info.m_border_color;
-			samplers[0].MinLOD = 0.0f;
-			samplers[0].MaxLOD = D3D12_FLOAT32_MAX;
-			samplers[0].ShaderRegister = i;
-			samplers[0].RegisterSpace = 0;
-			samplers[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL; // TODO: very inneficient. plz fix
+			samplers[i].Filter = (D3D12_FILTER)sampler_info.m_filter;
+			samplers[i].AddressU = (D3D12_TEXTURE_ADDRESS_MODE)sampler_info.m_address_mode;
+			samplers[i].AddressV = (D3D12_TEXTURE_ADDRESS_MODE)sampler_info.m_address_mode;
+			samplers[i].AddressW = (D3D12_TEXTURE_ADDRESS_MODE)sampler_info.m_address_mode;
+			samplers[i].MipLODBias = 0;
+			samplers[i].MaxAnisotropy = 0;
+			samplers[i].ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+			samplers[i].BorderColor = (D3D12_STATIC_BORDER_COLOR)sampler_info.m_border_color;
+			samplers[i].MinLOD = 0.0f;
+			samplers[i].MaxLOD = D3D12_FLOAT32_MAX;
+			samplers[i].ShaderRegister = i;
+			samplers[i].RegisterSpace = 0;
+			samplers[i].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL; // TODO: very inneficient. plz fix
 		}
 
 		D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;

--- a/src/imgui_tools.cpp
+++ b/src/imgui_tools.cpp
@@ -239,6 +239,9 @@ namespace wr::imgui::window
 
 			ImGui::End();
 
+			if (lights.size() < 1)
+				return;
+
 			auto ml = lights[0];
 			DirectX::XMFLOAT4X4 rmat;
 			auto mat = DirectX::XMMatrixTranslationFromVector(ml->m_position);


### PR DESCRIPTION
[Fix #0] "Engine crashes if there's no light, try putting checks for that to avoid a crash"

[Fix] Allow multiple samplers