### PR TITLE
[EDIT]: Fixed misalignment of sky boxes

### DIFF
--- a/resources/shaders/deferred_composition.hlsl
+++ b/resources/shaders/deferred_composition.hlsl
@@ -9,7 +9,7 @@ Texture2D gbuffer_albedo_roughness : register(t0);
 Texture2D gbuffer_normal_metallic : register(t1);
 Texture2D gbuffer_depth : register(t2);
 //Consider SRV for light buffer in register t3
-TextureCube skybox : register(t4);
+Texture2D skybox : register(t4);
 TextureCube irradiance_map : register(t5);
 RWTexture2D<float4> output : register(u0);
 SamplerState s0 : register(s0);
@@ -60,7 +60,7 @@ void main_cs(int3 dispatch_thread_id : SV_DispatchThreadID)
 
 		const float shadow_factor = 1.0f;
 		
-		float3 skybox_reflection = skybox.SampleLevel(s0, reflect(V, normal), 0);
+		float3 skybox_reflection = skybox.SampleLevel(s0, SampleSphericalMap(reflect(V, normal)), 0);
 
 		retval = shade_pixel(pos, V, albedo, metallic, roughness, normal, sampled_irradiance, skybox_reflection);
 
@@ -68,7 +68,7 @@ void main_cs(int3 dispatch_thread_id : SV_DispatchThreadID)
 	}
 	else
 	{	
-		retval = skybox.SampleLevel(s0, V, 0);
+		retval = skybox.SampleLevel(s0, SampleSphericalMap(V), 0);
 	}
 
 	//Do shading

--- a/resources/shaders/raytracing.hlsl
+++ b/resources/shaders/raytracing.hlsl
@@ -113,16 +113,6 @@ uint3 Load3x32BitIndices(uint offsetBytes)
  	return g_indices.Load3(offsetBytes);
 }
 
-float2 VectorToLatLong(float3 dir)
-{
-	float3 p = normalize(dir);
-
-	// atan2_WAR is a work-around due to an apparent compiler bug in atan2
-	float u = (1.f + atan2(p.x, -p.z) / M_PI) * 0.5f;
-	float v = acos(p.y*-1) / M_PI;
-	return float2(u, v);
-}
-
 inline Ray GenerateCameraRay(uint2 index, in float3 cameraPosition, in float4x4 projectionToWorld, in float2 offset, unsigned int seed)
 {
 #ifdef DEPTH_OF_FIELD
@@ -252,13 +242,7 @@ void RaygenEntry()
 [shader("miss")]
 void MissEntry(inout HitInfo payload)
 {
-	// Load some information about our lightprobe texture
-	float2 dims;
-	skybox.GetDimensions(dims.x, dims.y);
-
-	// Convert our ray direction to a (u,v) coordinate
-	float2 uv = VectorToLatLong(WorldRayDirection());
-	payload.color = skybox[uint2(uv * dims)].rgb;
+	payload.color = skybox.SampleLevel(s0, SampleSphericalMap(-WorldRayDirection()), 0);
 }
 
 float3 HitAttribute(float3 a, float3 b, float3 c, BuiltInTriangleIntersectionAttributes attr)

--- a/resources/shaders/rt_hybrid.hlsl
+++ b/resources/shaders/rt_hybrid.hlsl
@@ -243,27 +243,6 @@ float3 DoReflection(float3 wpos, float3 V, float3 normal, float roughness, float
 
 #define M_PI 3.14159265358979
 
-float2 VectorToLatLong(float3 dir)
-{
-	float3 p = normalize(dir);
-
-	// atan2_WAR is a work-around due to an apparent compiler bug in atan2
-	float u = (1.f + atan2(p.x, -p.z) / M_PI) * 0.5f;
-	float v = acos(p.y*-1) / M_PI;
-	return float2(u, v);
-}
-
-float3 SampleSkybox(float3 dir)
-{
-	// Load some information about our lightprobe texture
-	float2 dims;
-	skybox.GetDimensions(dims.x, dims.y);
-
-	// Convert our ray direction to a (u,v) coordinate
-	float2 uv = VectorToLatLong(dir);
-	return skybox[uint2(uv * dims)].rgb;
-}
-
 [shader("raygeneration")]
 void RaygenEntry()
 {
@@ -292,7 +271,7 @@ void RaygenEntry()
 
 	if (length(normal) == 0)		//TODO: Could be optimized by only marking pixels that need lighting, but that would require execute rays indirect
 	{
-		gOutput[DispatchRaysIndex().xy] = float4(SampleSkybox(-V), 1);
+		gOutput[DispatchRaysIndex().xy] = float4(skybox.SampleLevel(s0, SampleSphericalMap(V), 0));//, 1);
 		return;
 	}
 
@@ -395,5 +374,5 @@ void ReflectionHit(inout ReflectionHitInfo payload, in MyAttributes attr)
 [shader("miss")]
 void ReflectionMiss(inout ReflectionHitInfo payload)
 {
-	payload.color = SampleSkybox(WorldRayDirection());
+	payload.color = skybox.SampleLevel(s0, SampleSphericalMap(-WorldRayDirection()), 0);
 }

--- a/resources/shaders/rt_hybrid.hlsl
+++ b/resources/shaders/rt_hybrid.hlsl
@@ -271,7 +271,7 @@ void RaygenEntry()
 
 	if (length(normal) == 0)		//TODO: Could be optimized by only marking pixels that need lighting, but that would require execute rays indirect
 	{
-		gOutput[DispatchRaysIndex().xy] = float4(skybox.SampleLevel(s0, SampleSphericalMap(V), 0));//, 1);
+		gOutput[DispatchRaysIndex().xy] = float4(skybox.SampleLevel(s0, SampleSphericalMap(V), 0));
 		return;
 	}
 

--- a/src/render_tasks/d3d12_deferred_composition.hpp
+++ b/src/render_tasks/d3d12_deferred_composition.hpp
@@ -108,7 +108,7 @@ namespace wr
 					//d3d12::CreateSRVFromTexture(skybox_texture_resource, cpu_handle);
 					//Offset(cpu_handle, 1, data.out_srv_heap->m_increment_size);
 
-					auto* skybox_texture_resource = static_cast<wr::d3d12::TextureResource*>(pred_data.in_radiance.m_pool->GetTexture(pred_data.in_radiance.m_id));
+					auto* skybox_texture_resource = static_cast<wr::d3d12::TextureResource*>(pred_data.in_radiance.m_pool->GetTexture(skybox->m_hdr.m_id));
 					d3d12::CreateSRVFromTexture(skybox_texture_resource, cpu_handle);
 					Offset(cpu_handle, 1, data.out_srv_heap->m_increment_size);
 				}


### PR DESCRIPTION
Changed the deferred renderer to use equirectangular skybox to be more in line with (hybrid) raytracing. Made both raytracing pipelines use the PBR-util function to get the uvs for sampling the skybox so it works :)