### PR TITLE
Feature fix mipmapping

### DIFF
--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -14,7 +14,7 @@
 
 #include "model_loader_assimp.hpp"
 
-#define SCENE viknell_scene
+#define SCENE emibl_scene
 
 std::unique_ptr<wr::D3D12RenderSystem> render_system;
 std::shared_ptr<wr::SceneGraph> scene_graph;

--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -14,7 +14,7 @@
 
 #include "model_loader_assimp.hpp"
 
-#define SCENE emibl_scene
+#define SCENE viknell_scene
 
 std::unique_ptr<wr::D3D12RenderSystem> render_system;
 std::shared_ptr<wr::SceneGraph> scene_graph;

--- a/demo/resources.hpp
+++ b/demo/resources.hpp
@@ -82,10 +82,10 @@ namespace resources
 		wr::TextureHandle copper_roughness =	texture_pool->Load("resources/materials/copper_scuffed/roughness.png",	false, true);
 		wr::TextureHandle copper_metallic =		texture_pool->Load("resources/materials/copper_scuffed/metallic.png",	false, true);
 
-		wr::TextureHandle rusted_iron_albedo =		texture_pool->Load("resources/materials/rusted_iron_alt/albedo.dds", true, true);
-		wr::TextureHandle rusted_iron_normal =		texture_pool->Load("resources/materials/rusted_iron_alt/normal.dds", false, true);
-		wr::TextureHandle rusted_iron_roughness =	texture_pool->Load("resources/materials/rusted_iron_alt/roughness.dds", false, true);
-		wr::TextureHandle rusted_iron_metallic =	texture_pool->Load("resources/materials/rusted_iron_alt/metallic.dds", false, true);
+		wr::TextureHandle rusted_iron_albedo =		texture_pool->Load("resources/materials/rusted_iron_alt/albedo.png", true, true);
+		wr::TextureHandle rusted_iron_normal =		texture_pool->Load("resources/materials/rusted_iron_alt/normal.png", false, true);
+		wr::TextureHandle rusted_iron_roughness =	texture_pool->Load("resources/materials/rusted_iron_alt/roughness.png", false, true);
+		wr::TextureHandle rusted_iron_metallic =	texture_pool->Load("resources/materials/rusted_iron_alt/metallic.png", false, true);
 
 		wr::TextureHandle gold_albedo =		texture_pool->Load("resources/materials/gold_scuffed/albedo_boosted.png", true, true);
 		wr::TextureHandle gold_normal =		texture_pool->Load("resources/materials/gold_scuffed/normal.png", false, true);

--- a/demo/resources.hpp
+++ b/demo/resources.hpp
@@ -82,10 +82,10 @@ namespace resources
 		wr::TextureHandle copper_roughness =	texture_pool->Load("resources/materials/copper_scuffed/roughness.png",	false, true);
 		wr::TextureHandle copper_metallic =		texture_pool->Load("resources/materials/copper_scuffed/metallic.png",	false, true);
 
-		wr::TextureHandle rusted_iron_albedo =		texture_pool->Load("resources/materials/rusted_iron_alt/albedo.png", true, true);
-		wr::TextureHandle rusted_iron_normal =		texture_pool->Load("resources/materials/rusted_iron_alt/normal.png", false, true);
-		wr::TextureHandle rusted_iron_roughness =	texture_pool->Load("resources/materials/rusted_iron_alt/roughness.png", false, true);
-		wr::TextureHandle rusted_iron_metallic =	texture_pool->Load("resources/materials/rusted_iron_alt/metallic.png", false, true);
+		wr::TextureHandle rusted_iron_albedo =		texture_pool->Load("resources/materials/rusted_iron_alt/albedo.dds", true, true);
+		wr::TextureHandle rusted_iron_normal =		texture_pool->Load("resources/materials/rusted_iron_alt/normal.dds", false, true);
+		wr::TextureHandle rusted_iron_roughness =	texture_pool->Load("resources/materials/rusted_iron_alt/roughness.dds", false, true);
+		wr::TextureHandle rusted_iron_metallic =	texture_pool->Load("resources/materials/rusted_iron_alt/metallic.dds", false, true);
 
 		wr::TextureHandle gold_albedo =		texture_pool->Load("resources/materials/gold_scuffed/albedo_boosted.png", true, true);
 		wr::TextureHandle gold_normal =		texture_pool->Load("resources/materials/gold_scuffed/normal.png", false, true);

--- a/resources/shaders/basic.hlsl
+++ b/resources/shaders/basic.hlsl
@@ -78,8 +78,7 @@ PS_OUTPUT main_ps(VS_OUTPUT input) : SV_TARGET
 {
 	PS_OUTPUT output;
 	float3x3 tbn = {input.tangent, input.bitangent, input.normal};
-	//float4 albedo = pow(material_albedo.SampleLevel(s0, input.uv, 0), 2.2);
-	float4 albedo = pow(material_albedo.Sample(s0, input.uv), 2.2);
+	float4 albedo = material_albedo.Sample(s0, input.uv);
 //#define COMPRESSED_PBR
 #ifdef COMPRESSED_PBR
 	float4 roughness = material_metallic.SampleLevel(s0, input.uv, 0).y;

--- a/resources/shaders/basic.hlsl
+++ b/resources/shaders/basic.hlsl
@@ -78,7 +78,8 @@ PS_OUTPUT main_ps(VS_OUTPUT input) : SV_TARGET
 {
 	PS_OUTPUT output;
 	float3x3 tbn = {input.tangent, input.bitangent, input.normal};
-	float4 albedo = pow(material_albedo.SampleLevel(s0, input.uv, 0), 2.2);
+	//float4 albedo = pow(material_albedo.SampleLevel(s0, input.uv, 0), 2.2);
+	float4 albedo = pow(material_albedo.Sample(s0, input.uv), 2.2);
 //#define COMPRESSED_PBR
 #ifdef COMPRESSED_PBR
 	float4 roughness = material_metallic.SampleLevel(s0, input.uv, 0).y;

--- a/resources/shaders/deferred_composition.hlsl
+++ b/resources/shaders/deferred_composition.hlsl
@@ -65,6 +65,8 @@ void main_cs(int3 dispatch_thread_id : SV_DispatchThreadID)
 		retval = shade_pixel(pos, V, albedo, metallic, roughness, normal, sampled_irradiance, skybox_reflection);
 
 		retval = retval * shadow_factor;
+
+		retval = normal;
 	}
 	else
 	{	

--- a/resources/shaders/deferred_composition.hlsl
+++ b/resources/shaders/deferred_composition.hlsl
@@ -66,7 +66,7 @@ void main_cs(int3 dispatch_thread_id : SV_DispatchThreadID)
 
 		retval = retval * shadow_factor;
 
-		retval = normal;
+		retval = albedo;
 	}
 	else
 	{	

--- a/resources/shaders/deferred_composition.hlsl
+++ b/resources/shaders/deferred_composition.hlsl
@@ -66,7 +66,7 @@ void main_cs(int3 dispatch_thread_id : SV_DispatchThreadID)
 
 		retval = retval * shadow_factor;
 
-		retval = albedo;
+		retval = normal;
 	}
 	else
 	{	

--- a/resources/shaders/deferred_composition.hlsl
+++ b/resources/shaders/deferred_composition.hlsl
@@ -65,8 +65,6 @@ void main_cs(int3 dispatch_thread_id : SV_DispatchThreadID)
 		retval = shade_pixel(pos, V, albedo, metallic, roughness, normal, sampled_irradiance, skybox_reflection);
 
 		retval = retval * shadow_factor;
-
-		retval = normal;
 	}
 	else
 	{	

--- a/src/d3d12/d3d12_enums.hpp
+++ b/src/d3d12/d3d12_enums.hpp
@@ -165,7 +165,8 @@ namespace wr
 	enum class Format
 	{
 		UNKNOWN = (int)DXGI_FORMAT_UNKNOWN,
-		R10G10B10A2 = (int)DXGI_FORMAT_R10G10B10A2_UNORM,
+		R10G10B10A2_UNORM = (int)DXGI_FORMAT_R10G10B10A2_UNORM,
+		R10G10B10A2_UINT = (int)DXGI_FORMAT_R10G10B10A2_UINT,
 		R32G32B32A32_FLOAT = (int)DXGI_FORMAT_R32G32B32A32_FLOAT,
 		R32G32B32A32_UINT = (int)DXGI_FORMAT_R32G32B32A32_UINT,
 		R32G32B32A32_SINT = (int)DXGI_FORMAT_R32G32B32A32_SINT,
@@ -182,6 +183,7 @@ namespace wr
 		R32G32_SINT = (int)DXGI_FORMAT_R32G32_SINT,
 		//R10G10B10_UNORM = (int)DXGI_FORMAT_R10G10B10_UNORM,
 		//R10G10B10_UINT = (int)vk::Format::eA2R10G10B10UintPack32, //FIXME: Their are more vulcan variants?
+		R11G11B10_FLOAT = (int)DXGI_FORMAT_R11G11B10_FLOAT,
 		R8G8B8A8_UNORM = (int)DXGI_FORMAT_R8G8B8A8_UNORM,
 		R8G8B8A8_UNORM_SRGB = (int)DXGI_FORMAT_R8G8B8A8_UNORM_SRGB,
 		R8G8B8A8_SNORM = (int)DXGI_FORMAT_R8G8B8A8_SNORM,
@@ -189,6 +191,7 @@ namespace wr
 		R8G8B8A8_SINT = (int)DXGI_FORMAT_R8G8B8A8_SINT,
 		R16G16_FLOAT = (int)DXGI_FORMAT_R16G16_FLOAT,
 		R16G16_UINT = (int)DXGI_FORMAT_R16G16_UINT,
+		R16G16_UNORM = (int)DXGI_FORMAT_R16G16_UNORM,
 		R16G16_SNORM = (int)DXGI_FORMAT_R16G16_SNORM,
 		R16G16_SINT = (int)DXGI_FORMAT_R16G16_SINT,
 		D32_FLOAT = (int)DXGI_FORMAT_D32_FLOAT,
@@ -198,20 +201,21 @@ namespace wr
 		R32_FLOAT = (int)DXGI_FORMAT_R32_FLOAT,
 		R16_UNORM = (int)DXGI_FORMAT_R16_UNORM,
 		D24_UNFORM_S8_UINT = (int)DXGI_FORMAT_D24_UNORM_S8_UINT,
-		//R8G8_UNORM = (int)vk::Format::eR8G8Unorm,
-		//R8G8_UINT = (int)vk::Format::eR8G8Uint,
-		//R8G8_SNORM = (int)vk::Format::eR8G8Snorm,
-		//R8G8_SINT = (int)vk::Format::eR8G8Sint,
+		R8G8_UNORM = (int)DXGI_FORMAT_R8G8_UNORM,
+		R8G8_UINT = (int)DXGI_FORMAT_R8G8_UINT,
+		R8G8_SNORM = (int)DXGI_FORMAT_R8G8_SNORM,
+		R8G8_SINT = (int)DXGI_FORMAT_R8G8_SINT,
 		R16_FLOAT = (int)DXGI_FORMAT_R16_FLOAT,
 		//D16_UNORM = (int)vk::Format::eD16Unorm,
 		//R16_UNORM = (int)vk::Format::eR16Unorm,
 		R16_UINT = (int)DXGI_FORMAT_R16_UINT,
-		//R16_SNORM = (int)vk::Format::eR16Snorm,
+		R16_SNORM = (int)DXGI_FORMAT_R16_SNORM,
 		R16_SINT = (int)DXGI_FORMAT_R16_SINT,
 		R8_UNORM = (int)DXGI_FORMAT_R8_UNORM,
 		R8_UINT = (int)DXGI_FORMAT_R8_UINT,
 		R8_SNORM = (int)DXGI_FORMAT_R8_SNORM,
 		R8_SINT = (int)DXGI_FORMAT_R8_SINT,
+		A8_UNORM = (int)DXGI_FORMAT_A8_UNORM,
 		//BC1_UNORM = (int)vk::Format::eBc1RgbUnormBlock, //FIXME: is this correct?
 		//BC1_UNORM_SRGB = (int)vk::Format::eBc1RgbSrgbBlock, //FIXME: is this correct?
 		//BC2_UNORM = (int)vk::Format::eBc2UnormBlock,
@@ -222,8 +226,8 @@ namespace wr
 		//BC4_SNORM = (int)vk::Format::eBc4SnormBlock,
 		//BC5_UNORM = (int)vk::Format::eBc5UnormBlock,
 		//BC5_SNORM = (int)vk::Format::eBc5SnormBlock,
-		//B5G6R5_UNORM = (int)vk::Format::eB5G6R5UnormPack16,
-		//B5G5R5A1_UNORM = (int)vk::Format::eB5G5R5A1UnormPack16,
+		B5G6R5_UNORM = (int)DXGI_FORMAT_B5G6R5_UNORM,
+		B5G5R5A1_UNORM = (int)DXGI_FORMAT_B5G5R5A1_UNORM,
 		B8G8R8A8_UNORM = (int)DXGI_FORMAT_B8G8R8A8_UNORM,
 		B8G8R8A8_UNORM_SRGB = (int)DXGI_FORMAT_B8G8R8A8_UNORM_SRGB,
 		//B8G8R8A8_SNORM = (int)vk::Format::eB8G8R8A8Snorm,
@@ -235,7 +239,7 @@ namespace wr
 		//BC6H_SF16 = (int)vk::Format::eBc6HSfloatBlock,
 		//BC7_UNORM = (int)vk::Format::eBc7UnormBlock,
 		//BC7_UNORM_SRGB = (int)vk::Format::eBc7SrgbBlock,
-		//B4G4R4A4_UNORM = (int)vk::Format::eB4G4R4A4UnormPack16,
+		B4G4R4A4_UNORM = (int)DXGI_FORMAT_B4G4R4A4_UNORM,
 		D32_FLOAT_S8X24_UINT = (int)DXGI_FORMAT_D32_FLOAT_S8X24_UINT,
 	};
 
@@ -269,6 +273,26 @@ namespace wr
 		case Format::R32_FLOAT: return "R32_FLOAT";
 		case Format::D24_UNFORM_S8_UINT: return "D24_UNFORM_S8_UINT";
 		case Format::R8_UNORM: return "R8_UNORM";
+		case Format::R10G10B10A2_UNORM: return "R10G10B10A2_UNORM";
+		case Format::R10G10B10A2_UINT: return "R10G10B10A2_UINT";
+		case Format::R11G11B10_FLOAT: return "R11G11B10_FLOAT";
+		case Format::R16G16_FLOAT: return "R16G16_FLOAT";
+		case Format::R16G16_UNORM: return "R16G16_UNORM";
+		case Format::R16G16_UINT: return "R16G16_UINT";
+		case Format::R16G16_SNORM: return "R16G16_SNORM";
+		case Format::R16G16_SINT: return "R16G16_SINT";
+		case Format::R8G8_UNORM: return "R8G8_UNORM";
+		case Format::R8G8_UINT: return "R8G8_UINT";
+		case Format::R8G8_SNORM: return "R8G8_SNORM";
+		case Format::R8G8_SINT: return "R8G8_SINT";
+		case Format::R16_UNORM: return "R16_UNORM";
+		case Format::R16_SNORM: return "R16_SNORM";
+		case Format::R8_SNORM: return "R8_SNORM";
+		case Format::A8_UNORM: return "A8_UNORM";
+		case Format::B5G6R5_UNORM: return "B5G6R5_UNORM";
+		case Format::B5G5R5A1_UNORM: return "B5G5R5A1_UNORM";
+		case Format::B4G4R4A4_UNORM: return "B4G4R4A4_UNORM";
+
 		default: return "UNKNOWN (DEFAULT SWITCH STATEMENT)";
 		}
 	}
@@ -310,9 +334,9 @@ namespace wr
 			return 64;
 
 		//case Format::R10G10B10A2_TYPELESS:
-		//case Format::R10G10B10A2_UNORM:
-		//case Format::R10G10B10A2_UINT:
-		//case Format::R11G11B10_FLOAT:
+		case Format::R10G10B10A2_UNORM:
+		case Format::R10G10B10A2_UINT:
+		case Format::R11G11B10_FLOAT:
 		//case Format::R8G8B8A8_TYPELESS:
 		case Format::R8G8B8A8_UNORM:
 		case Format::R8G8B8A8_UNORM_SRGB:
@@ -321,7 +345,7 @@ namespace wr
 		case Format::R8G8B8A8_SINT:
 		//case Format::R16G16_TYPELESS:
 		case Format::R16G16_FLOAT:
-		//case Format::R16G16_UNORM:
+		case Format::R16G16_UNORM:
 		case Format::R16G16_UINT:
 		case Format::R16G16_SNORM:
 		case Format::R16G16_SINT:
@@ -354,21 +378,21 @@ namespace wr
 		//	return 24;
 
 		//case Format::R8G8_TYPELESS:
-		//case Format::R8G8_UNORM:
-		//case Format::R8G8_UINT:
-		//case Format::R8G8_SNORM:
-		//case Format::R8G8_SINT:
+		case Format::R8G8_UNORM:
+		case Format::R8G8_UINT:
+		case Format::R8G8_SNORM:
+		case Format::R8G8_SINT:
 		//case Format::R16_TYPELESS:
 		case Format::R16_FLOAT:
 		//case Format::D16_UNORM:
 		case Format::R16_UNORM:
 		case Format::R16_UINT:
-		//case Format::R16_SNORM:
+		case Format::R16_SNORM:
 		case Format::R16_SINT:
-		//case Format::B5G6R5_UNORM:
-		//case Format::B5G5R5A1_UNORM:
+		case Format::B5G6R5_UNORM:
+		case Format::B5G5R5A1_UNORM:
 		//case Format::A8P8:
-		//case Format::B4G4R4A4_UNORM:
+		case Format::B4G4R4A4_UNORM:
 			return 16;
 
 		//case Format::NV12:
@@ -381,7 +405,7 @@ namespace wr
 		case Format::R8_UINT:
 		case Format::R8_SNORM:
 		case Format::R8_SINT:
-		//case Format::A8_UNORM:
+		case Format::A8_UNORM:
 		//case Format::AI44:
 		//case Format::IA44:
 		//case Format::P8:

--- a/src/d3d12/d3d12_functions.hpp
+++ b/src/d3d12/d3d12_functions.hpp
@@ -108,6 +108,11 @@ namespace wr::d3d12
 	void SetShaderUAV(wr::d3d12::CommandList* cmd_list, uint32_t rootParameterIndex, uint32_t descriptorOffset, TextureResource* tex);
 	void Destroy(TextureResource* tex);
 
+	bool CheckUAVCompatibility(Format format);
+	bool CheckBGRFormat(Format format);
+	bool CheckSRGBFormat(Format format);
+
+
 	// Read-back buffer
 	[[nodiscard]] ReadbackBufferResource* CreateReadbackBuffer(Device* device, desc::ReadbackDesc* description);
 	void* MapReadbackBuffer(ReadbackBufferResource* const readback_buffer, std::uint64_t buffer_size);

--- a/src/d3d12/d3d12_functions.hpp
+++ b/src/d3d12/d3d12_functions.hpp
@@ -100,12 +100,15 @@ namespace wr::d3d12
 	void SetName(TextureResource* tex, std::wstring name);
 	void CreateSRVFromTexture(TextureResource* tex);
 	void CreateSRVFromTexture(TextureResource* tex, DescHeapCPUHandle& handle);
+	void CreateSRVFromTexture(TextureResource* tex, DescHeapCPUHandle& handle, unsigned int mip_levels, unsigned int most_detailed_mip);
 	void CreateUAVFromTexture(TextureResource* tex, DescHeapCPUHandle& handle, unsigned int mip_slice);
 	void CreateRTVFromTexture2D(TextureResource* tex);
 	void CreateRTVFromCubemap(TextureResource* tex);
 	//void CreateUAVFromTexture(TextureResource* tex, DescHeapCPUHandle& handle, unsigned int mip_slice = 0, unsigned int array_slice = 0);
 	void SetShaderSRV(wr::d3d12::CommandList* cmd_list, uint32_t rootParameterIndex, uint32_t descriptorOffset, TextureResource* tex);
+	void SetShaderSRV(wr::d3d12::CommandList* cmd_list, uint32_t rootParameterIndex, uint32_t descriptorOffset, d3d12::DescHeapCPUHandle& handle);
 	void SetShaderUAV(wr::d3d12::CommandList* cmd_list, uint32_t rootParameterIndex, uint32_t descriptorOffset, TextureResource* tex);
+	void SetShaderUAV(wr::d3d12::CommandList* cmd_list, uint32_t rootParameterIndex, uint32_t descriptorOffset, d3d12::DescHeapCPUHandle& handle);
 	void Destroy(TextureResource* tex);
 
 	bool CheckUAVCompatibility(Format format);

--- a/src/d3d12/d3d12_functions.hpp
+++ b/src/d3d12/d3d12_functions.hpp
@@ -109,6 +109,7 @@ namespace wr::d3d12
 	void SetShaderSRV(wr::d3d12::CommandList* cmd_list, uint32_t rootParameterIndex, uint32_t descriptorOffset, d3d12::DescHeapCPUHandle& handle);
 	void SetShaderUAV(wr::d3d12::CommandList* cmd_list, uint32_t rootParameterIndex, uint32_t descriptorOffset, TextureResource* tex);
 	void SetShaderUAV(wr::d3d12::CommandList* cmd_list, uint32_t rootParameterIndex, uint32_t descriptorOffset, d3d12::DescHeapCPUHandle& handle);
+	void CopyResource(wr::d3d12::CommandList* cmd_list, TextureResource* src_texture, TextureResource* dst_texture);
 	void Destroy(TextureResource* tex);
 
 	// Format test and support functions
@@ -117,6 +118,7 @@ namespace wr::d3d12
 	bool CheckBGRFormat(Format format);
 	bool CheckSRGBFormat(Format format);
 	bool IsOptionalFormatSupported(Device* device, Format format);
+	Format RemoveSRGB(Format format);
 
 	// Read-back buffer
 	[[nodiscard]] ReadbackBufferResource* CreateReadbackBuffer(Device* device, desc::ReadbackDesc* description);

--- a/src/d3d12/d3d12_functions.hpp
+++ b/src/d3d12/d3d12_functions.hpp
@@ -111,10 +111,12 @@ namespace wr::d3d12
 	void SetShaderUAV(wr::d3d12::CommandList* cmd_list, uint32_t rootParameterIndex, uint32_t descriptorOffset, d3d12::DescHeapCPUHandle& handle);
 	void Destroy(TextureResource* tex);
 
+	// Format test and support functions
 	bool CheckUAVCompatibility(Format format);
+	bool CheckOptionalUAVFormat(Format format);
 	bool CheckBGRFormat(Format format);
 	bool CheckSRGBFormat(Format format);
-
+	bool IsOptionalFormatSupported(Device* device, Format format);
 
 	// Read-back buffer
 	[[nodiscard]] ReadbackBufferResource* CreateReadbackBuffer(Device* device, desc::ReadbackDesc* description);

--- a/src/d3d12/d3d12_resource_pool_texture.cpp
+++ b/src/d3d12/d3d12_resource_pool_texture.cpp
@@ -328,7 +328,9 @@ namespace wr
 
 		uint32_t mip_lvls;
 
-		if (generate_mips)
+		bool mip_generation = (metadata.mipLevels > 1) ? false : generate_mips;
+
+		if (mip_generation)
 		{
 			mip_lvls = static_cast<uint32_t>(std::floor(std::log2(std::max(metadata.width, metadata.height)))) + 1;
 		}
@@ -348,7 +350,7 @@ namespace wr
 		desc.m_texture_format = static_cast<wr::Format>(metadata.format);
 		desc.m_initial_state = ResourceState::COPY_DEST;
 
-		auto texture = d3d12::CreateTexture(device, &desc, generate_mips);
+		auto texture = d3d12::CreateTexture(device, &desc, mip_generation);
 
 		texture->m_allocated_memory = static_cast<uint8_t*>(malloc(texture->m_needed_memory));
 
@@ -361,7 +363,7 @@ namespace wr
 			LOGC("Couldn't allocate descriptor for the texture resource");
 		}
 
-		texture->m_need_mips = generate_mips;
+		texture->m_need_mips = mip_generation;
 		texture->m_srv_allocation = std::move(alloc);
 		texture->m_resource->SetName(wide_string.c_str());
 
@@ -575,66 +577,9 @@ namespace wr
 
 	void D3D12TexturePool::GenerateMips_BGR(std::vector<d3d12::TextureResource*>& const textures, CommandList* cmd_list)
 	{
-
 	}
 
 	void D3D12TexturePool::GenerateMips_SRGB(std::vector<d3d12::TextureResource*>& const textures, CommandList* cmd_list)
 	{
-	}
-
-	bool D3D12TexturePool::CheckUAVCompatibility(Format format)
-	{
-		switch (format)
-		{
-		case Format::R32G32B32A32_FLOAT:
-		case Format::R32G32B32A32_UINT:
-		case Format::R32G32B32A32_SINT:
-		case Format::R16G16B16A16_FLOAT:
-		//case Format::R16G16B16A16_UNORM:
-		case Format::R16G16B16A16_UINT:
-		case Format::R16G16B16A16_SINT:
-		case Format::R8G8B8A8_UNORM:
-		case Format::R8G8B8A8_UINT:
-		case Format::R8G8B8A8_SINT:
-		case Format::R32_FLOAT:
-		case Format::R32_UINT:
-		case Format::R32_SINT:
-		case Format::R16_FLOAT:
-		case Format::R16_UINT:
-		case Format::R16_SINT:
-		case Format::R8_UNORM:
-		case Format::R8_UINT:
-		case Format::R8_SINT:
-			return true;
-		default:
-			return false;
-		}
-	}
-
-	bool D3D12TexturePool::CheckBGRFormat(Format format)
-	{
-		switch (format)
-		{
-		case Format::B8G8R8A8_UNORM:
-		case Format::B8G8R8X8_UNORM:
-		case Format::B8G8R8A8_UNORM_SRGB:
-		case Format::B8G8R8X8_UNORM_SRGB:
-			return true;
-		default:
-			return false;
-		}
-	}
-
-	bool D3D12TexturePool::CheckSRGBFormat(Format format)
-	{
-		switch (format)
-		{
-		case Format::R8G8B8A8_UNORM_SRGB:
-		case Format::B8G8R8A8_UNORM_SRGB:
-		case Format::B8G8R8X8_UNORM_SRGB:
-			return true;
-		default:
-			return false;
-		}
 	}
 }

--- a/src/d3d12/d3d12_resource_pool_texture.hpp
+++ b/src/d3d12/d3d12_resource_pool_texture.hpp
@@ -57,6 +57,9 @@ namespace wr
 		DescriptorAllocator* m_allocators[static_cast<size_t>(DescriptorHeapType::DESC_HEAP_TYPE_NUM_TYPES)];
 
 		DescriptorAllocator* m_mipmapping_allocator;
+
+		//Track resources that are created in one frame and destroyed after
+		std::vector<d3d12::TextureResource*> m_temporary_textures;
 	};
 
 

--- a/src/d3d12/d3d12_resource_pool_texture.hpp
+++ b/src/d3d12/d3d12_resource_pool_texture.hpp
@@ -54,11 +54,7 @@ namespace wr
 		//Renderer will copy the descriptor it needs to the GPU visible heap used for rendering.
 		DescriptorAllocator* m_allocators[static_cast<size_t>(DescriptorHeapType::DESC_HEAP_TYPE_NUM_TYPES)];
 
-
-		//Descriptor heap used for compute pipeline when doing mipmapping
-		d3d12::DescriptorHeap* m_mipmapping_heap;
-		d3d12::DescHeapCPUHandle m_mipmapping_cpu_handle;
-		d3d12::DescHeapGPUHandle m_mipmapping_gpu_handle;
+		DescriptorAllocator* m_mipmapping_allocator;
 	};
 
 

--- a/src/d3d12/d3d12_resource_pool_texture.hpp
+++ b/src/d3d12/d3d12_resource_pool_texture.hpp
@@ -43,10 +43,12 @@ namespace wr
 		d3d12::TextureResource* LoadHDR(std::string_view path, bool srgb, bool generate_mips) final;
 
 		void MoveStagedTextures();
+		void GenerateMips(d3d12::TextureResource* texture, CommandList* cmd_list);
 		void GenerateMips(std::vector<d3d12::TextureResource*>& const textures, CommandList* cmd_list);
-		void GenerateMips_UAV(std::vector<d3d12::TextureResource*>& const textures, CommandList* cmd_list);
-		void GenerateMips_BGR(std::vector<d3d12::TextureResource*>& const textures, CommandList* cmd_list);
-		void GenerateMips_SRGB(std::vector<d3d12::TextureResource*>& const textures, CommandList* cmd_list);
+
+		void GenerateMips_UAV(d3d12::TextureResource* texture, CommandList* cmd_list);
+		void GenerateMips_BGR(d3d12::TextureResource* texture, CommandList* cmd_list);
+		void GenerateMips_SRGB(d3d12::TextureResource* texture, CommandList* cmd_list);
 
 		D3D12RenderSystem& m_render_system;
 

--- a/src/d3d12/d3d12_resource_pool_texture.hpp
+++ b/src/d3d12/d3d12_resource_pool_texture.hpp
@@ -48,10 +48,6 @@ namespace wr
 		void GenerateMips_BGR(std::vector<d3d12::TextureResource*>& const textures, CommandList* cmd_list);
 		void GenerateMips_SRGB(std::vector<d3d12::TextureResource*>& const textures, CommandList* cmd_list);
 
-		bool CheckUAVCompatibility(Format format);
-		bool CheckBGRFormat(Format format);
-		bool CheckSRGBFormat(Format format);
-
 		D3D12RenderSystem& m_render_system;
 
 		//CPU only visible heaps used for staging of descriptors.

--- a/src/d3d12/d3d12_settings.hpp
+++ b/src/d3d12/d3d12_settings.hpp
@@ -29,8 +29,8 @@ namespace wr::d3d12::settings
 	static const constexpr DXGI_SCALING swapchain_scaling = DXGI_SCALING_STRETCH;
 	static const constexpr DXGI_ALPHA_MODE swapchain_alpha_mode = DXGI_ALPHA_MODE_UNSPECIFIED;
 	static const constexpr bool enable_gpu_timeout = false;
-	static const constexpr bool enable_debug_factory = false;
-	static const constexpr DebugLayer enable_debug_layer = DebugLayer::DISABLE;	//Don't use ENABLE_WITH_GPU_VALIDATION (Raytracing); it breaks
+	static const constexpr bool enable_debug_factory = true;
+	static const constexpr DebugLayer enable_debug_layer = DebugLayer::ENABLE_WITH_GPU_VALIDATION;	//Don't use ENABLE_WITH_GPU_VALIDATION (Raytracing); it breaks
 	static const constexpr char* default_shader_model = "6_3";
 	static std::array<LPCWSTR, 1> debug_shader_args = { L"/O3" };
 	static std::array<LPCWSTR, 1> release_shader_args = { L"/O3" };

--- a/src/d3d12/d3d12_settings.hpp
+++ b/src/d3d12/d3d12_settings.hpp
@@ -30,7 +30,7 @@ namespace wr::d3d12::settings
 	static const constexpr DXGI_ALPHA_MODE swapchain_alpha_mode = DXGI_ALPHA_MODE_UNSPECIFIED;
 	static const constexpr bool enable_gpu_timeout = false;
 	static const constexpr bool enable_debug_factory = true;
-	static const constexpr DebugLayer enable_debug_layer = DebugLayer::ENABLE_WITH_GPU_VALIDATION;	//Don't use ENABLE_WITH_GPU_VALIDATION (Raytracing); it breaks
+	static const constexpr DebugLayer enable_debug_layer = DebugLayer::ENABLE;	//Don't use ENABLE_WITH_GPU_VALIDATION (Raytracing); it breaks
 	static const constexpr char* default_shader_model = "6_3";
 	static std::array<LPCWSTR, 1> debug_shader_args = { L"/O3" };
 	static std::array<LPCWSTR, 1> release_shader_args = { L"/O3" };

--- a/src/d3d12/d3d12_structs.hpp
+++ b/src/d3d12/d3d12_structs.hpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <dxcapi.h>
 #include <array>
+#include <bitset>
 #include <D3D12RaytracingFallback.h>
 
 #include "../structs.hpp"
@@ -143,6 +144,9 @@ namespace wr::d3d12
 		ID3D12InfoQueue* m_info_queue;
 		
 		static IDxcCompiler2* m_compiler;
+
+		// Optional supported formats
+		std::bitset<DXGI_FORMAT_V408> m_optional_formats;
 
 		// Fallback
 		bool m_dxr_fallback_support;

--- a/src/d3d12/d3d12_textures.cpp
+++ b/src/d3d12/d3d12_textures.cpp
@@ -437,6 +437,41 @@ namespace wr::d3d12
 		}
 	}
 
+	bool CheckOptionalUAVFormat(Format format)
+	{
+		switch (format)
+		{
+		case Format::R16G16B16A16_UNORM:
+		case Format::R16G16B16A16_SNORM:
+		case Format::R32G32_FLOAT:
+		case Format::R32G32_UINT:
+		case Format::R32G32_SINT:
+		case Format::R10G10B10A2_UNORM:
+		case Format::R10G10B10A2_UINT:
+		case Format::R11G11B10_FLOAT:
+		case Format::R8G8B8A8_SNORM:
+		case Format::R16G16_FLOAT:
+		case Format::R16G16_UNORM:
+		case Format::R16G16_UINT:
+		case Format::R16G16_SNORM:
+		case Format::R16G16_SINT:
+		case Format::R8G8_UNORM:
+		case Format::R8G8_UINT:
+		case Format::R8G8_SNORM:
+		case Format::R8G8_SINT:
+		case Format::R16_UNORM:
+		case Format::R16_SNORM:
+		case Format::R8_SNORM:
+		case Format::A8_UNORM:
+		case Format::B5G6R5_UNORM:
+		case Format::B5G5R5A1_UNORM:
+		case Format::B4G4R4A4_UNORM:
+			return true;
+		default:
+			return false;
+		}
+	}
+
 	bool CheckBGRFormat(Format format)
 	{
 		switch (format)
@@ -462,6 +497,11 @@ namespace wr::d3d12
 		default:
 			return false;
 		}
+	}
+
+	bool IsOptionalFormatSupported(Device* device, Format format)
+	{
+		return true;
 	}
 
 } /* wr::d3d12 */

--- a/src/d3d12/d3d12_textures.cpp
+++ b/src/d3d12/d3d12_textures.cpp
@@ -11,7 +11,16 @@ namespace wr::d3d12
 	{
 		D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE;
 
-		if (allow_uav) { flags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS; }
+		if (allow_uav) 
+		{ 
+			//if (!d3d12::CheckUAVCompatibility(description->m_texture_format))
+			//{
+			//	LOGC("[ERROR] CreateTexture: Specified format doesn't support UAV");
+			//}
+
+			flags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS; 
+		}
+
 		if (description->m_initial_state == ResourceState::RENDER_TARGET) { flags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET; }
 
 		D3D12_RESOURCE_DESC desc = {};
@@ -305,5 +314,59 @@ namespace wr::d3d12
 		delete tex;
 	}
 
+	bool CheckUAVCompatibility(Format format)
+	{
+		switch (format)
+		{
+		case Format::R32G32B32A32_FLOAT:
+		case Format::R32G32B32A32_UINT:
+		case Format::R32G32B32A32_SINT:
+		case Format::R16G16B16A16_FLOAT:
+		case Format::R16G16B16A16_UINT:
+		case Format::R16G16B16A16_SINT:
+		case Format::R8G8B8A8_UNORM:
+		case Format::R8G8B8A8_UINT:
+		case Format::R8G8B8A8_SINT:
+		case Format::R32_FLOAT:
+		case Format::R32_UINT:
+		case Format::R32_SINT:
+		case Format::R16_FLOAT:
+		case Format::R16_UINT:
+		case Format::R16_SINT:
+		case Format::R8_UNORM:
+		case Format::R8_UINT:
+		case Format::R8_SINT:
+			return true;
+		default:
+			return false;
+		}
+	}
+
+	bool CheckBGRFormat(Format format)
+	{
+		switch (format)
+		{
+		case Format::B8G8R8A8_UNORM:
+		case Format::B8G8R8X8_UNORM:
+		case Format::B8G8R8A8_UNORM_SRGB:
+		case Format::B8G8R8X8_UNORM_SRGB:
+			return true;
+		default:
+			return false;
+		}
+	}
+
+	bool CheckSRGBFormat(Format format)
+	{
+		switch (format)
+		{
+		case Format::R8G8B8A8_UNORM_SRGB:
+		case Format::B8G8R8A8_UNORM_SRGB:
+		case Format::B8G8R8X8_UNORM_SRGB:
+			return true;
+		default:
+			return false;
+		}
+	}
 
 } /* wr::d3d12 */

--- a/src/d3d12/d3d12_textures.cpp
+++ b/src/d3d12/d3d12_textures.cpp
@@ -515,7 +515,7 @@ namespace wr::d3d12
 
 	bool IsOptionalFormatSupported(Device* device, Format format)
 	{
-		return true;
+		return device->m_optional_formats.test(static_cast<DXGI_FORMAT>(format));
 	}
 
 	Format RemoveSRGB(Format format)


### PR DESCRIPTION
Refactored mipmapping, added sRGB textures mipmapping (no BGR textures yet, they seem to work when treated as RGB). Added new texture formats support checking in the engine and functions to check and/or modify formats. Removed pow when sampling albedo textures in the shader cause they're now correctly sRGB.