### PR TITLE
[EDIT]: Properly release Heap resources instead of deleting it

### DIFF
--- a/src/d3d12/d3d12_heap.cpp
+++ b/src/d3d12/d3d12_heap.cpp
@@ -849,7 +849,7 @@ namespace wr::d3d12
 			delete resource.first;
 			for (auto& n_resource : resource.second)
 			{
-				delete n_resource;
+				SAFE_RELEASE(n_resource);
 			}
 		}
 		delete heap;


### PR DESCRIPTION
### Fix for #169 
The issue was caused by deleting an ID3D12Resource instead of releasing it. Crash prevented, resource cleaned up 👌 