### PR TITLE
Feature expanding mipmapping support

### DIFF
--- a/resources/shaders/generate_mips_cs.hlsl
+++ b/resources/shaders/generate_mips_cs.hlsl
@@ -1,22 +1,218 @@
-Texture2D<float4> src_texture : register(t0);
-RWTexture2D<float4> dst_texture : register(u0);
-SamplerState bilinear_clamp : register(s0);
+/**
+* Compute shader to generate mipmaps for a given texture.
+* Source: https://github.com/Microsoft/DirectX-Graphics-Samples/blob/master/MiniEngine/Core/Shaders/GenerateMipsCS.hlsli
+*/
 
-cbuffer CB : register(b0)
+#define BLOCK_SIZE 8
+
+// When reducing the size of a texture, it could be that downscaling the texture 
+// will result in a less than exactly 50% (1/2) of the original texture size.
+// This happens if either the width, or the height (or both) dimensions of the texture
+// are odd. For example, downscaling a 5x3 texture will result in a 2x1 texture which
+// has a 60% reduction in the texture width and 66% reduction in the height.
+// When this happens, we need to take more samples from the source texture to 
+// determine the pixel value in the destination texture.
+
+#define WIDTH_HEIGHT_EVEN 0     // Both the width and the height of the texture are even.
+#define WIDTH_ODD_HEIGHT_EVEN 1 // The texture width is odd and the height is even.
+#define WIDTH_EVEN_HEIGHT_ODD 2 // The texture width is even and teh height is odd.
+#define WIDTH_HEIGHT_ODD 3      // Both the width and height of the texture are odd.
+
+struct ComputeShaderInput
 {
-	float2 texel_size;   // 1.0 / destination dimension
+	uint3 GroupID           : SV_GroupID;           // 3D index of the thread group in the dispatch.
+	uint3 GroupThreadID     : SV_GroupThreadID;     // 3D index of local thread ID in a thread group.
+	uint3 DispatchThreadID  : SV_DispatchThreadID;  // 3D index of global thread ID in the dispatch.
+	uint  GroupIndex        : SV_GroupIndex;        // Flattened local index of the thread within a thread group.
+};
+
+cbuffer GenerateMipsCB : register(b0)
+{
+	uint SrcMipLevel;	// Texture level of source mip
+	uint NumMipLevels;	// Number of OutMips to write: [1-4]
+	uint SrcDimension;  // Width and height of the source texture are even or odd.
+	uint Padding;       // Pad to 16 byte alignment.
+	float2 TexelSize;	// 1.0 / OutMip1.Dimensions
 }
 
-[numthreads(8, 8, 1)]
-void main(uint3 dt_id : SV_DispatchThreadID)
+// Source mip map.
+Texture2D<float4> SrcMip : register(t0);
+
+// Write up to 4 mip map levels.
+RWTexture2D<float4> OutMip1 : register(u0);
+RWTexture2D<float4> OutMip2 : register(u1);
+RWTexture2D<float4> OutMip3 : register(u2);
+RWTexture2D<float4> OutMip4 : register(u3);
+
+// Linear clamp sampler.
+SamplerState LinearClampSampler : register(s0);
+
+// The reason for separating channels is to reduce bank conflicts in the
+// local data memory controller.  A large stride will cause more threads
+// to collide on the same memory bank.
+groupshared float gs_R[64];
+groupshared float gs_G[64];
+groupshared float gs_B[64];
+groupshared float gs_A[64];
+
+void StoreColor(uint Index, float4 Color)
 {
-	//DTid is the thread ID * the values from numthreads above and in this case correspond to the pixels location in number of pixels.
-	//As a result texcoords (in 0-1 range) will point at the center between the 4 pixels used for the mipmap.
-	float2 tex_coords = texel_size * (dt_id.xy + 0.5f);
+	gs_R[Index] = Color.r;
+	gs_G[Index] = Color.g;
+	gs_B[Index] = Color.b;
+	gs_A[Index] = Color.a;
+}
 
-	//The samplers linear interpolation will mix the four pixel values to the new pixels color
-	float4 color = src_texture.SampleLevel(bilinear_clamp, tex_coords, 0);
+float4 LoadColor(uint Index)
+{
+	return float4(gs_R[Index], gs_G[Index], gs_B[Index], gs_A[Index]);
+}
 
-	//Write the final color into the destination texture.
-	dst_texture[dt_id.xy] = color;
+float3 LinearToSRGB(float3 x)
+{
+	// This is exactly the sRGB curve
+	//return x < 0.0031308 ? 12.92 * x : 1.055 * pow(abs(x), 1.0 / 2.4) - 0.055;
+
+	// This is cheaper but nearly equivalent
+	return x < 0.0031308 ? 12.92 * x : 1.13005 * sqrt(abs(x - 0.00228)) - 0.13448 * x + 0.005719;
+}
+
+float4 PackColor(float4 Linear)
+{
+#if defined(CONVERT_TO_SRGB)
+	return float4(LinearToSRGB(Linear.rgb), Linear.a);
+#else
+	return Linear;
+#endif
+}
+
+[numthreads(BLOCK_SIZE, BLOCK_SIZE, 1)]
+void main(ComputeShaderInput IN)
+{
+	float4 Src1 = (float4)0;
+
+	// One bilinear sample is insufficient when scaling down by more than 2x.
+	// You will slightly undersample in the case where the source dimension
+	// is odd.  This is why it's a really good idea to only generate mips on
+	// power-of-two sized textures.  Trying to handle the undersampling case
+	// will force this shader to be slower and more complicated as it will
+	// have to take more source texture samples.
+
+	// Determine the path to use based on the dimension of the 
+	// source texture.
+	// 0b00(0): Both width and height are even.
+	// 0b01(1): Width is odd, height is even.
+	// 0b10(2): Width is even, height is odd.
+	// 0b11(3): Both width and height are odd.
+	switch (SrcDimension)
+	{
+	case WIDTH_HEIGHT_EVEN:
+	{
+		float2 UV = TexelSize * (IN.DispatchThreadID.xy + 0.5);
+
+		Src1 = SrcMip.SampleLevel(LinearClampSampler, UV, SrcMipLevel);
+	}
+	break;
+	case WIDTH_ODD_HEIGHT_EVEN:
+	{
+		// > 2:1 in X dimension
+		// Use 2 bilinear samples to guarantee we don't undersample when downsizing by more than 2x
+		// horizontally.
+		float2 UV1 = TexelSize * (IN.DispatchThreadID.xy + float2(0.25, 0.5));
+		float2 Off = TexelSize * float2(0.5, 0.0);
+
+		Src1 = 0.5 * (SrcMip.SampleLevel(LinearClampSampler, UV1, SrcMipLevel) +
+			SrcMip.SampleLevel(LinearClampSampler, UV1 + Off, SrcMipLevel));
+	}
+	break;
+	case WIDTH_EVEN_HEIGHT_ODD:
+	{
+		// > 2:1 in Y dimension
+		// Use 2 bilinear samples to guarantee we don't undersample when downsizing by more than 2x
+		// vertically.
+		float2 UV1 = TexelSize * (IN.DispatchThreadID.xy + float2(0.5, 0.25));
+		float2 Off = TexelSize * float2(0.0, 0.5);
+
+		Src1 = 0.5 * (SrcMip.SampleLevel(LinearClampSampler, UV1, SrcMipLevel) +
+			SrcMip.SampleLevel(LinearClampSampler, UV1 + Off, SrcMipLevel));
+	}
+	break;
+	case WIDTH_HEIGHT_ODD:
+	{
+		// > 2:1 in in both dimensions
+		// Use 4 bilinear samples to guarantee we don't undersample when downsizing by more than 2x
+		// in both directions.
+		float2 UV1 = TexelSize * (IN.DispatchThreadID.xy + float2(0.25, 0.25));
+		float2 Off = TexelSize * 0.5;
+
+		Src1 = SrcMip.SampleLevel(LinearClampSampler, UV1, SrcMipLevel);
+		Src1 += SrcMip.SampleLevel(LinearClampSampler, UV1 + float2(Off.x, 0.0), SrcMipLevel);
+		Src1 += SrcMip.SampleLevel(LinearClampSampler, UV1 + float2(0.0, Off.y), SrcMipLevel);
+		Src1 += SrcMip.SampleLevel(LinearClampSampler, UV1 + float2(Off.x, Off.y), SrcMipLevel);
+		Src1 *= 0.25;
+	}
+	break;
+	}
+
+	OutMip1[IN.DispatchThreadID.xy] = PackColor(Src1);
+
+	// A scalar (constant) branch can exit all threads coherently.
+	if (NumMipLevels == 1)
+		return;
+
+	// Without lane swizzle operations, the only way to share data with other
+	// threads is through LDS.
+	StoreColor(IN.GroupIndex, Src1);
+
+	// This guarantees all LDS writes are complete and that all threads have
+	// executed all instructions so far (and therefore have issued their LDS
+	// write instructions.)
+	GroupMemoryBarrierWithGroupSync();
+
+	// With low three bits for X and high three bits for Y, this bit mask
+	// (binary: 001001) checks that X and Y are even.
+	if ((IN.GroupIndex & 0x9) == 0)
+	{
+		float4 Src2 = LoadColor(IN.GroupIndex + 0x01);
+		float4 Src3 = LoadColor(IN.GroupIndex + 0x08);
+		float4 Src4 = LoadColor(IN.GroupIndex + 0x09);
+		Src1 = 0.25 * (Src1 + Src2 + Src3 + Src4);
+
+		OutMip2[IN.DispatchThreadID.xy / 2] = PackColor(Src1);
+		StoreColor(IN.GroupIndex, Src1);
+	}
+
+	if (NumMipLevels == 2)
+		return;
+
+	GroupMemoryBarrierWithGroupSync();
+
+	// This bit mask (binary: 011011) checks that X and Y are multiples of four.
+	if ((IN.GroupIndex & 0x1B) == 0)
+	{
+		float4 Src2 = LoadColor(IN.GroupIndex + 0x02);
+		float4 Src3 = LoadColor(IN.GroupIndex + 0x10);
+		float4 Src4 = LoadColor(IN.GroupIndex + 0x12);
+		Src1 = 0.25 * (Src1 + Src2 + Src3 + Src4);
+
+		OutMip3[IN.DispatchThreadID.xy / 4] = PackColor(Src1);
+		StoreColor(IN.GroupIndex, Src1);
+	}
+
+	if (NumMipLevels == 3)
+		return;
+
+	GroupMemoryBarrierWithGroupSync();
+
+	// This bit mask would be 111111 (X & Y multiples of 8), but only one
+	// thread fits that criteria.
+	if (IN.GroupIndex == 0)
+	{
+		float4 Src2 = LoadColor(IN.GroupIndex + 0x04);
+		float4 Src3 = LoadColor(IN.GroupIndex + 0x20);
+		float4 Src4 = LoadColor(IN.GroupIndex + 0x24);
+		Src1 = 0.25 * (Src1 + Src2 + Src3 + Src4);
+
+		OutMip4[IN.DispatchThreadID.xy / 8] = PackColor(Src1);
+	}
 }

--- a/src/d3d12/d3d12_functions.hpp
+++ b/src/d3d12/d3d12_functions.hpp
@@ -61,6 +61,8 @@ namespace wr::d3d12
 	void Transition(CommandList* cmd_list, RenderTarget* render_target, unsigned int frame_index, ResourceState from, ResourceState to);
 	void Transition(CommandList* cmd_list, RenderTarget* render_target, ResourceState from, ResourceState to);
 	void Transition(CommandList* cmd_list, TextureResource* texture, ResourceState from, ResourceState to);
+	void Transition(CommandList* cmd_list, TextureResource* texture, ResourceState from, ResourceState to, unsigned int first_subresource, unsigned int num_subresources);
+	void TransitionSubresource(CommandList* cmd_list, TextureResource* texture, ResourceState from, ResourceState to, unsigned int subresource);
 	void Transition(CommandList* cmd_list, std::vector<TextureResource*> const& textures, ResourceState from, ResourceState to);
 	void Transition(CommandList* cmd_list, IndirectCommandBuffer* buffer, ResourceState from, ResourceState to, uint32_t frame_idx);
 	void Transition(CommandList* cmd_list, StagingBuffer* buffer, ResourceState from, ResourceState to);

--- a/src/d3d12/d3d12_resource_pool_texture.cpp
+++ b/src/d3d12/d3d12_resource_pool_texture.cpp
@@ -291,6 +291,22 @@ namespace wr
 			mip_lvls = metadata.mipLevels;
 		}
 
+		Format adjusted_format;
+
+		if (srgb)
+		{
+			adjusted_format = static_cast<wr::Format>(DirectX::MakeSRGB(metadata.format));
+		}
+		else
+		{
+			adjusted_format = static_cast<wr::Format>(metadata.format);
+
+			if (d3d12::CheckSRGBFormat(adjusted_format))
+			{
+				adjusted_format = d3d12::RemoveSRGB(adjusted_format);
+			}
+		}
+
 		d3d12::desc::TextureDesc desc;
 
 		desc.m_width = metadata.width;
@@ -299,7 +315,7 @@ namespace wr
 		desc.m_depth = metadata.depth;
 		desc.m_array_size = metadata.arraySize;
 		desc.m_mip_levels = mip_lvls;
-		desc.m_texture_format = (srgb) ? static_cast<wr::Format>(DirectX::MakeSRGB(metadata.format)) : static_cast<wr::Format>(metadata.format);
+		desc.m_texture_format = adjusted_format;
 		desc.m_initial_state = ResourceState::COPY_DEST;
 
 		auto texture = d3d12::CreateTexture(device, &desc, generate_mips);
@@ -356,6 +372,22 @@ namespace wr
 			mip_lvls = metadata.mipLevels;
 		}
 
+		Format adjusted_format;
+
+		if (srgb)
+		{
+			adjusted_format = static_cast<wr::Format>(DirectX::MakeSRGB(metadata.format));
+		}
+		else
+		{
+			adjusted_format = static_cast<wr::Format>(metadata.format);
+
+			if (d3d12::CheckSRGBFormat(adjusted_format))
+			{
+				adjusted_format = d3d12::RemoveSRGB(adjusted_format);
+			}
+		}
+
 		d3d12::desc::TextureDesc desc;
 
 		desc.m_width = metadata.width;
@@ -364,7 +396,7 @@ namespace wr
 		desc.m_depth = metadata.depth;
 		desc.m_array_size = metadata.arraySize;
 		desc.m_mip_levels = mip_lvls;
-		desc.m_texture_format = static_cast<wr::Format>(metadata.format);
+		desc.m_texture_format = adjusted_format;
 		desc.m_initial_state = ResourceState::COPY_DEST;
 
 		auto texture = d3d12::CreateTexture(device, &desc, mip_generation);
@@ -418,6 +450,22 @@ namespace wr
 			mip_lvls = metadata.mipLevels;
 		}
 
+		Format adjusted_format;
+
+		if (srgb)
+		{
+			adjusted_format = static_cast<wr::Format>(DirectX::MakeSRGB(metadata.format));
+		}
+		else
+		{
+			adjusted_format = static_cast<wr::Format>(metadata.format);
+
+			if (d3d12::CheckSRGBFormat(adjusted_format))
+			{
+				adjusted_format = d3d12::RemoveSRGB(adjusted_format);
+			}
+		}
+
 		d3d12::desc::TextureDesc desc;
 
 		desc.m_width = metadata.width;
@@ -426,7 +474,7 @@ namespace wr
 		desc.m_depth = metadata.depth;
 		desc.m_array_size = metadata.arraySize;
 		desc.m_mip_levels = mip_lvls;
-		desc.m_texture_format = static_cast<wr::Format>(metadata.format);
+		desc.m_texture_format = adjusted_format;
 		desc.m_initial_state = ResourceState::COPY_DEST;
 
 		auto texture = d3d12::CreateTexture(device, &desc, generate_mips);

--- a/src/d3d12/d3d12_resource_pool_texture.cpp
+++ b/src/d3d12/d3d12_resource_pool_texture.cpp
@@ -1,3 +1,31 @@
+/*
+The mipmapping implementation used in this framework is a ported version of 
+MiniEngine's implementation.
+*/
+/*
+The MIT License(MIT)
+
+Copyright(c) 2013 - 2015 Microsoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 #include "d3d12_resource_pool_texture.hpp"
 
 #include "d3d12_functions.hpp"

--- a/src/d3d12/d3d12_resource_pool_texture.cpp
+++ b/src/d3d12/d3d12_resource_pool_texture.cpp
@@ -146,7 +146,6 @@ namespace wr
 		}
 	}
 
-
 	void D3D12TexturePool::PostStageClear()
 	{
 		
@@ -566,7 +565,7 @@ namespace wr
 
 		MipMapping_CB generate_mips_cb;
 
-		for (uint32_t src_mip = 0; src_mip < texture->m_mip_levels - 1u; src_mip++)
+		for (uint32_t src_mip = 0; src_mip < texture->m_mip_levels - 1u;)
 		{
 			uint32_t src_width = texture->m_width >> src_mip;
 			uint32_t src_height = texture->m_height >> src_mip;

--- a/src/d3d12/d3d12_resource_pool_texture.hpp
+++ b/src/d3d12/d3d12_resource_pool_texture.hpp
@@ -10,7 +10,11 @@ namespace wr
 {
 	struct MipMapping_CB
 	{
-		DirectX::XMFLOAT2 TexelSize;	// 1.0 / OutMip1.Dimensions
+		uint32_t src_mip_level;			// Texture level of source mip
+		uint32_t num_mip_levels;		// Number of OutMips to write: [1-4]
+		uint32_t src_dimension;			// Width and height of the source texture are even or odd.
+		uint32_t padding;				// Pad to 16 byte alignment.
+		DirectX::XMFLOAT2 texel_size;	// 1.0 / OutMip1.Dimensions
 	};
 
 	class D3D12RenderSystem;
@@ -60,6 +64,9 @@ namespace wr
 		//Track resources that are created in one frame and destroyed after
 		std::array<std::vector<d3d12::TextureResource*>, d3d12::settings::num_back_buffers> m_temporary_textures;
 		std::array< std::vector<d3d12::Heap<wr::HeapOptimization::BIG_STATIC_BUFFERS>*>, d3d12::settings::num_back_buffers> m_temporary_heaps;
+
+		//Default UAV used for padding
+		DescriptorAllocation m_default_uav;
 	};
 
 

--- a/src/d3d12/d3d12_resource_pool_texture.hpp
+++ b/src/d3d12/d3d12_resource_pool_texture.hpp
@@ -1,3 +1,30 @@
+/*
+The mipmapping implementation used in this framework is a ported version of
+MiniEngine's implementation.
+*/
+/*
+The MIT License(MIT)
+
+Copyright(c) 2013 - 2015 Microsoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 #pragma once
 
 #include "../resource_pool_texture.hpp"

--- a/src/d3d12/d3d12_texture_resources.hpp
+++ b/src/d3d12/d3d12_texture_resources.hpp
@@ -21,7 +21,7 @@ namespace wr::d3d12
 
 		ID3D12Resource* m_resource;
 		ID3D12Resource* m_intermediate;
-		ResourceState m_current_state;
+		std::vector<ResourceState> m_subresource_states;
 		DescriptorAllocation m_srv_allocation;
 		DescriptorAllocation m_uav_allocation;
 

--- a/src/d3d12/d3d12_textures.cpp
+++ b/src/d3d12/d3d12_textures.cpp
@@ -75,13 +75,17 @@ namespace wr::d3d12
 		texture->m_array_size = description->m_array_size;
 		texture->m_mip_levels = description->m_mip_levels;
 		texture->m_format = description->m_texture_format;
-		texture->m_current_state = description->m_initial_state;
 		texture->m_resource = resource;
 		texture->m_intermediate = intermediate;
 		texture->m_need_mips = (texture->m_mip_levels > 1);
 		texture->m_is_cubemap = description->m_is_cubemap;
 		texture->m_is_staged = false;
 		texture->m_needed_memory = textureUploadBufferSize;
+
+		for (uint32_t i = 0; i < description->m_mip_levels; ++i)
+		{
+			texture->m_subresource_states.push_back(description->m_initial_state);
+		}
 
 		return texture;
 	}
@@ -137,13 +141,17 @@ namespace wr::d3d12
 		texture->m_array_size = description->m_array_size;
 		texture->m_mip_levels = description->m_mip_levels;
 		texture->m_format = description->m_texture_format;
-		texture->m_current_state = description->m_initial_state;
 		texture->m_resource = resource;
 		texture->m_intermediate = nullptr;
 		texture->m_need_mips = (texture->m_mip_levels > 1);
 		texture->m_is_cubemap = description->m_is_cubemap;
 		texture->m_is_staged = false;
 		texture->m_needed_memory = 0;
+
+		for (uint32_t i = 0; i < description->m_mip_levels; ++i)
+		{
+			texture->m_subresource_states.push_back(description->m_initial_state);
+		}
 
 		return texture;
 	}
@@ -465,8 +473,8 @@ namespace wr::d3d12
 
 	void CopyResource(wr::d3d12::CommandList* cmd_list, TextureResource* src_texture, TextureResource* dst_texture)
 	{
-		ResourceState src_original_state = src_texture->m_current_state;
-		ResourceState dst_original_state = dst_texture->m_current_state;
+		ResourceState src_original_state = src_texture->m_subresource_states[0];
+		ResourceState dst_original_state = dst_texture->m_subresource_states[0];
 
 		d3d12::Transition(cmd_list, src_texture, src_original_state, ResourceState::COPY_SOURCE);
 		d3d12::Transition(cmd_list, dst_texture, dst_original_state, ResourceState::COPY_DEST);

--- a/src/engine_registry.cpp
+++ b/src/engine_registry.cpp
@@ -75,7 +75,7 @@ namespace wr
 	);
 	REGISTER(root_signatures::mip_mapping, RootSignatureRegistry)({
 		RootSignatureDescription::Parameters({
-			ROOT_PARAM(GetConstants(params::mip_mapping, params::MipMappingE::TEXEL_SIZE)),
+			ROOT_PARAM(GetConstants(params::mip_mapping, params::MipMappingE::CBUFFER)),
 			ROOT_PARAM_DESC_TABLE(mip_in_out_ranges, D3D12_SHADER_VISIBILITY_ALL)
 		}),
 		RootSignatureDescription::Samplers({

--- a/src/engine_registry.hpp
+++ b/src/engine_registry.hpp
@@ -301,13 +301,13 @@ namespace wr
 		{
 			SOURCE,
 			DEST,
-			TEXEL_SIZE,
+			CBUFFER,
 		};
 
 		constexpr std::array<rs_layout::Entry, 3> mip_mapping = {
 			rs_layout::Entry{(int)MipMappingE::SOURCE, 1, rs_layout::Type::SRV_RANGE},
-			rs_layout::Entry{(int)MipMappingE::DEST, 1, rs_layout::Type::UAV_RANGE},
-			rs_layout::Entry{(int)MipMappingE::TEXEL_SIZE, 2, rs_layout::Type::CBV_OR_CONST},
+			rs_layout::Entry{(int)MipMappingE::DEST, 4, rs_layout::Type::UAV_RANGE},
+			rs_layout::Entry{(int)MipMappingE::CBUFFER, 6, rs_layout::Type::CBV_OR_CONST},
 		};
 
 		enum class CubemapConversionE

--- a/src/render_tasks/d3d12_cubemap_convolution.hpp
+++ b/src/render_tasks/d3d12_cubemap_convolution.hpp
@@ -176,7 +176,7 @@ namespace wr
 						}
 					}
 
-					d3d12::Transition(cmd_list, irradiance, irradiance->m_current_state, ResourceState::PIXEL_SHADER_RESOURCE);
+					d3d12::Transition(cmd_list, irradiance, irradiance->m_subresource_states[0], ResourceState::PIXEL_SHADER_RESOURCE);
 
 					data.should_run = false;
 				}

--- a/src/render_tasks/d3d12_equirect_to_cubemap.hpp
+++ b/src/render_tasks/d3d12_equirect_to_cubemap.hpp
@@ -165,7 +165,7 @@ namespace wr
 					}
 				}
 
-				d3d12::Transition(cmd_list, cubemap_text, cubemap_text->m_current_state, ResourceState::PIXEL_SHADER_RESOURCE);
+				d3d12::Transition(cmd_list, cubemap_text, cubemap_text->m_subresource_states[0], ResourceState::PIXEL_SHADER_RESOURCE);
 			}
 		}
 	} /* internal */


### PR DESCRIPTION
Added MiniEngine's implementation of mipmapping. Now properly supports non-squared textures, non power of 2 textures, etc.
I also now creates 4 mip levels with each compute pass.
The engine also received some updates to accept the new implementation. As an example, since a subresource in a texture can be transitioned to another state, but not the whole resource, now TextureResource keeps track of the current state of each subresource