### PR TITLE
Fix for materials without bound textures

### DIFF
--- a/src/d3d12/d3d12_material_pool.cpp
+++ b/src/d3d12/d3d12_material_pool.cpp
@@ -5,7 +5,7 @@ namespace wr
 	D3D12MaterialPool::D3D12MaterialPool(D3D12RenderSystem & render_system) :
 		m_render_system(render_system)
 	{
-		m_constant_buffer_pool = m_render_system.CreateConstantBufferPool(1 * 1024 * 1024);		
+		m_constant_buffer_pool = m_render_system.CreateConstantBufferPool(1_mb);		
 	}
 
 	D3D12MaterialPool::~D3D12MaterialPool()

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -1093,17 +1093,56 @@ namespace wr
 
 		D3D12ConstantBufferHandle* handle = static_cast<D3D12ConstantBufferHandle*>(material_internal->GetConstantBufferHandle());
 
+		D3D12TexturePool* texture_pool = static_cast<D3D12TexturePool*>(material_internal->GetTexturePool());
+
+		if (texture_pool == nullptr)
+		{
+			texture_pool = static_cast<D3D12TexturePool*>(m_texture_pools[0].get());
+		}
+
 		auto albedo_handle = material_internal->GetAlbedo();
-		auto* albedo_internal = static_cast<wr::d3d12::TextureResource*>(albedo_handle.m_pool->GetTexture(albedo_handle.m_id));
+		wr::d3d12::TextureResource* albedo_internal;
+		if (albedo_handle.m_pool == nullptr)
+		{
+			albedo_internal = texture_pool->GetTexture(texture_pool->GetDefaultAlbedo().m_id);
+		}
+		else
+		{
+			albedo_internal = static_cast<wr::d3d12::TextureResource*>(albedo_handle.m_pool->GetTexture(albedo_handle.m_id));
+		}
 
 		auto normal_handle = material_internal->GetNormal();
-		auto* normal_internal = static_cast<wr::d3d12::TextureResource*>(normal_handle.m_pool->GetTexture(normal_handle.m_id));
+		wr::d3d12::TextureResource* normal_internal;
+		if (normal_handle.m_pool == nullptr)
+		{
+			normal_internal = texture_pool->GetTexture(texture_pool->GetDefaultNormal().m_id);
+		}
+		else
+		{
+			normal_internal = static_cast<wr::d3d12::TextureResource*>(normal_handle.m_pool->GetTexture(normal_handle.m_id));
+		}
 
 		auto roughness_handle = material_internal->GetRoughness();
-		auto* roughness_internal = static_cast<wr::d3d12::TextureResource*>(roughness_handle.m_pool->GetTexture(roughness_handle.m_id));
+		wr::d3d12::TextureResource* roughness_internal;
+		if (roughness_handle.m_pool == nullptr)
+		{
+			roughness_internal = texture_pool->GetTexture(texture_pool->GetDefaultRoughness().m_id);
+		}
+		else
+		{
+			roughness_internal = static_cast<wr::d3d12::TextureResource*>(roughness_handle.m_pool->GetTexture(roughness_handle.m_id));
+		}
 
 		auto metallic_handle = material_internal->GetMetallic();
-		auto* metallic_internal = static_cast<wr::d3d12::TextureResource*>(metallic_handle.m_pool->GetTexture(metallic_handle.m_id));
+		wr::d3d12::TextureResource* metallic_internal;
+		if (metallic_handle.m_pool == nullptr)
+		{
+			metallic_internal = texture_pool->GetTexture(texture_pool->GetDefaultMetalic().m_id);
+		}
+		else
+		{
+			metallic_internal = static_cast<wr::d3d12::TextureResource*>(metallic_handle.m_pool->GetTexture(metallic_handle.m_id));
+		}
 
 		d3d12::SetShaderSRV(n_cmd_list, 2, COMPILATION_EVAL(rs_layout::GetHeapLoc(params::basic, params::BasicE::ALBEDO)), albedo_internal);
 		d3d12::SetShaderSRV(n_cmd_list, 2, COMPILATION_EVAL(rs_layout::GetHeapLoc(params::basic, params::BasicE::NORMAL)), normal_internal);

--- a/src/material_pool.cpp
+++ b/src/material_pool.cpp
@@ -15,6 +15,12 @@ namespace wr
 	Material::Material()
 	{
 		memset(&m_material_data, 0, sizeof(m_material_data));
+
+		m_albedo = { nullptr,0 };
+		m_normal = { nullptr,0 };
+		m_rougness = { nullptr,0 };
+		m_metallic = { nullptr,0 };
+		m_ao = { nullptr,0 };
 	}
 
 	Material::Material(TextureHandle albedo,
@@ -54,6 +60,10 @@ namespace wr
 		}
 		else
 		{
+			if (!m_texture_pool)
+			{
+				m_texture_pool = albedo.m_pool;
+			}
 			m_albedo = albedo;
 			m_material_data.m_material_flags.m_has_albedo_texture = true;
 			
@@ -77,6 +87,10 @@ namespace wr
 		}
 		else
 		{
+			if (!m_texture_pool)
+			{
+				m_texture_pool = normal.m_pool;
+			}
 			m_normal = normal;
 			m_material_data.m_material_flags.m_has_normal_texture = true;
 			
@@ -99,6 +113,10 @@ namespace wr
 		}
 		else
 		{
+			if (!m_texture_pool)
+			{
+				m_texture_pool = roughness.m_pool;
+			}
 			m_rougness = roughness;
 			m_material_data.m_material_flags.m_has_roughness_texture = true;
 		}
@@ -120,6 +138,10 @@ namespace wr
 		}
 		else
 		{
+			if (!m_texture_pool)
+			{
+				m_texture_pool = metallic.m_pool;
+			}
 			m_metallic = metallic;
 			m_material_data.m_material_flags.m_has_metallic_texture = true;
 		}
@@ -141,6 +163,10 @@ namespace wr
 		}
 		else
 		{
+			if (!m_texture_pool)
+			{
+				m_texture_pool = ao.m_pool;
+			}
 			m_ao = ao;
 			m_material_data.m_material_flags.m_has_ao_texture = true;
 		}


### PR DESCRIPTION
Fixed the engine crashing when creating a material without bound textures. Now when binding the material the renderer will automatically replace any missing textures with the default textures.