### PR TITLE
Support for copying data to non 256-byte aligned buffer sizes

### DIFF
--- a/src/d3d12/d3d12_readback_buffer.cpp
+++ b/src/d3d12/d3d12_readback_buffer.cpp
@@ -3,7 +3,6 @@
 #include "d3d12_defines.hpp"
 #include "d3dx12.hpp"
 #include "../util/log.hpp"
-#include "../util/math.hpp"
 
 namespace wr::d3d12
 {
@@ -13,7 +12,7 @@ namespace wr::d3d12
 
 		auto* readbackBuffer = new ReadbackBufferResource();
 
-		std::uint32_t buffer_size_aligned_to_256 = util::RoundUpToNearestMultiple(description->m_buffer_width * description->m_bytes_per_pixel, 256) * description->m_buffer_height;
+		std::uint32_t buffer_size_aligned_to_256 = SizeAlign(description->m_buffer_width * description->m_bytes_per_pixel, 256) * description->m_buffer_height;
 
 		HRESULT res = native_device->CreateCommittedResource(
 			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK),

--- a/src/d3d12/d3d12_readback_buffer.cpp
+++ b/src/d3d12/d3d12_readback_buffer.cpp
@@ -1,8 +1,9 @@
 #include "d3d12_functions.hpp"
 
-#include "../util/log.hpp"
 #include "d3d12_defines.hpp"
 #include "d3dx12.hpp"
+#include "../util/log.hpp"
+#include "../util/math.hpp"
 
 namespace wr::d3d12
 {
@@ -12,10 +13,12 @@ namespace wr::d3d12
 
 		auto* readbackBuffer = new ReadbackBufferResource();
 
+		std::uint32_t buffer_size_aligned_to_256 = util::RoundUpToNearestMultiple(description->m_buffer_width * description->m_bytes_per_pixel, 256) * description->m_buffer_height;
+
 		HRESULT res = native_device->CreateCommittedResource(
 			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK),
 			D3D12_HEAP_FLAG_NONE,
-			&CD3DX12_RESOURCE_DESC::Buffer(description->m_buffer_width * description->m_buffer_height * description->m_bytes_per_pixel),
+			&CD3DX12_RESOURCE_DESC::Buffer(buffer_size_aligned_to_256),
 			D3D12_RESOURCE_STATE_COPY_DEST,
 			nullptr,
 			IID_PPV_ARGS(&readbackBuffer->m_resource));

--- a/src/render_tasks/d3d12_depth_data_readback.hpp
+++ b/src/render_tasks/d3d12_depth_data_readback.hpp
@@ -4,7 +4,6 @@
 #include "d3d12/d3d12_renderer.hpp"
 #include "d3d12/d3d12_structs.hpp"
 #include "frame_graph/frame_graph.hpp"
-#include "util/math.hpp"
 
 namespace wr
 {
@@ -50,7 +49,7 @@ namespace wr
 			d3d12::SetName(data.readback_buffer, L"Depth data read back render pass");
 
 			// Size of the buffer aligned to a multiple of 256
-			std::uint32_t aligned_buffer_size = util::RoundUpToNearestMultiple(data.readback_buffer_desc.m_buffer_width * bytesPerPixel, 256) * data.readback_buffer_desc.m_buffer_height;
+			std::uint32_t aligned_buffer_size = SizeAlign(data.readback_buffer_desc.m_buffer_width * bytesPerPixel, 256) * data.readback_buffer_desc.m_buffer_height;
 
 			// Keep the read back buffer mapped for the duration of the entire application
 			data.cpu_texture_output.m_data = reinterpret_cast<float*>(MapReadbackBuffer(data.readback_buffer, aligned_buffer_size));
@@ -75,7 +74,7 @@ namespace wr
 			destination.PlacedFootprint.Footprint.Depth = 1;
 
 			std::uint32_t row_pitch = destination.PlacedFootprint.Footprint.Width * BytesPerPixel(data.predecessor_render_target->m_create_info.m_dsv_format);
-			std::uint32_t aligned_row_pitch = util::RoundUpToNearestMultiple(row_pitch, 256);	// 256 byte aligned
+			std::uint32_t aligned_row_pitch = SizeAlign(row_pitch, 256);	// 256 byte aligned
 
 			destination.PlacedFootprint.Footprint.RowPitch = aligned_row_pitch;
 

--- a/src/render_tasks/d3d12_depth_data_readback.hpp
+++ b/src/render_tasks/d3d12_depth_data_readback.hpp
@@ -45,14 +45,15 @@ namespace wr
 			data.readback_buffer_desc.m_buffer_height = dx12_render_system.m_viewport.m_viewport.Height;
 			data.readback_buffer_desc.m_bytes_per_pixel = bytesPerPixel;
 
-			std::uint64_t buffer_size = data.readback_buffer_desc.m_buffer_width * data.readback_buffer_desc.m_buffer_height * data.readback_buffer_desc.m_bytes_per_pixel;
-
 			// Create the actual read back buffer
 			data.readback_buffer = d3d12::CreateReadbackBuffer(dx12_render_system.m_device, &data.readback_buffer_desc);
 			d3d12::SetName(data.readback_buffer, L"Depth data read back render pass");
 
+			// Size of the buffer aligned to a multiple of 256
+			std::uint32_t aligned_buffer_size = util::RoundUpToNearestMultiple(data.readback_buffer_desc.m_buffer_width * bytesPerPixel, 256) * data.readback_buffer_desc.m_buffer_height;
+
 			// Keep the read back buffer mapped for the duration of the entire application
-			data.cpu_texture_output.m_data = reinterpret_cast<float*>(MapReadbackBuffer(data.readback_buffer, buffer_size));
+			data.cpu_texture_output.m_data = reinterpret_cast<float*>(MapReadbackBuffer(data.readback_buffer, aligned_buffer_size));
 			data.cpu_texture_output.m_buffer_width = data.readback_buffer_desc.m_buffer_width;
 			data.cpu_texture_output.m_buffer_height = data.readback_buffer_desc.m_buffer_height;
 			data.cpu_texture_output.m_bytes_per_pixel = data.readback_buffer_desc.m_bytes_per_pixel;

--- a/src/render_tasks/d3d12_depth_data_readback.hpp
+++ b/src/render_tasks/d3d12_depth_data_readback.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "../d3d12/d3d12_structs.hpp"
-#include "../d3d12/d3d12_renderer.hpp"
-#include "../d3d12/d3d12_functions.hpp"
-#include "../frame_graph/frame_graph.hpp"
+#include "d3d12/d3d12_functions.hpp"
+#include "d3d12/d3d12_renderer.hpp"
+#include "d3d12/d3d12_structs.hpp"
+#include "frame_graph/frame_graph.hpp"
+#include "util/math.hpp"
 
 namespace wr
 {
@@ -71,7 +72,11 @@ namespace wr
 			destination.PlacedFootprint.Footprint.Width = dx12_render_system.m_viewport.m_viewport.Width;
 			destination.PlacedFootprint.Footprint.Height = dx12_render_system.m_viewport.m_viewport.Height;
 			destination.PlacedFootprint.Footprint.Depth = 1;
-			destination.PlacedFootprint.Footprint.RowPitch = destination.PlacedFootprint.Footprint.Width * BytesPerPixel(data.predecessor_render_target->m_create_info.m_dsv_format);
+
+			std::uint32_t row_pitch = destination.PlacedFootprint.Footprint.Width * BytesPerPixel(data.predecessor_render_target->m_create_info.m_dsv_format);
+			std::uint32_t aligned_row_pitch = util::RoundUpToNearestMultiple(row_pitch, 256);	// 256 byte aligned
+
+			destination.PlacedFootprint.Footprint.RowPitch = aligned_row_pitch;
 
 			D3D12_TEXTURE_COPY_LOCATION source = {};
 			source.pResource = data.predecessor_render_target->m_depth_stencil_buffer;

--- a/src/render_tasks/d3d12_pixel_data_readback.hpp
+++ b/src/render_tasks/d3d12_pixel_data_readback.hpp
@@ -45,14 +45,15 @@ namespace wr
 			data.readback_buffer_desc.m_buffer_height = dx12_render_system.m_viewport.m_viewport.Height;
 			data.readback_buffer_desc.m_bytes_per_pixel = bytesPerPixel;
 
-			std::uint64_t buffer_size = data.readback_buffer_desc.m_buffer_width * data.readback_buffer_desc.m_buffer_height * data.readback_buffer_desc.m_bytes_per_pixel;
-
 			// Create the actual read back buffer
 			data.readback_buffer = d3d12::CreateReadbackBuffer(dx12_render_system.m_device, &data.readback_buffer_desc);
 			d3d12::SetName(data.readback_buffer, L"Pixel data read back render pass");
 
+			// Size of the buffer aligned to a multiple of 256
+			std::uint32_t aligned_buffer_size = util::RoundUpToNearestMultiple(data.readback_buffer_desc.m_buffer_width * bytesPerPixel, 256) * data.readback_buffer_desc.m_buffer_height;
+
 			// Keep the read back buffer mapped for the duration of the entire application
-			data.cpu_texture_output.m_data = reinterpret_cast<float*>(MapReadbackBuffer(data.readback_buffer, buffer_size));
+			data.cpu_texture_output.m_data = reinterpret_cast<float*>(MapReadbackBuffer(data.readback_buffer, aligned_buffer_size));
 			data.cpu_texture_output.m_buffer_width = data.readback_buffer_desc.m_buffer_width;
 			data.cpu_texture_output.m_buffer_height = data.readback_buffer_desc.m_buffer_height;
 			data.cpu_texture_output.m_bytes_per_pixel = data.readback_buffer_desc.m_bytes_per_pixel;

--- a/src/render_tasks/d3d12_pixel_data_readback.hpp
+++ b/src/render_tasks/d3d12_pixel_data_readback.hpp
@@ -4,7 +4,6 @@
 #include "d3d12/d3d12_renderer.hpp"
 #include "d3d12/d3d12_structs.hpp"
 #include "frame_graph/frame_graph.hpp"
-#include "util/math.hpp"
 
 namespace wr
 {
@@ -50,7 +49,7 @@ namespace wr
 			d3d12::SetName(data.readback_buffer, L"Pixel data read back render pass");
 
 			// Size of the buffer aligned to a multiple of 256
-			std::uint32_t aligned_buffer_size = util::RoundUpToNearestMultiple(data.readback_buffer_desc.m_buffer_width * bytesPerPixel, 256) * data.readback_buffer_desc.m_buffer_height;
+			std::uint32_t aligned_buffer_size = SizeAlign(data.readback_buffer_desc.m_buffer_width * bytesPerPixel, 256) * data.readback_buffer_desc.m_buffer_height;
 
 			// Keep the read back buffer mapped for the duration of the entire application
 			data.cpu_texture_output.m_data = reinterpret_cast<float*>(MapReadbackBuffer(data.readback_buffer, aligned_buffer_size));
@@ -75,7 +74,7 @@ namespace wr
 			destination.PlacedFootprint.Footprint.Depth = 1;
 
 			std::uint32_t row_pitch = destination.PlacedFootprint.Footprint.Width * BytesPerPixel(data.predecessor_render_target->m_create_info.m_rtv_formats[0]);
-			std::uint32_t aligned_row_pitch = util::RoundUpToNearestMultiple(row_pitch, 256);	// 256 byte aligned
+			std::uint32_t aligned_row_pitch = SizeAlign(row_pitch, 256);	// 256 byte aligned
 
 			destination.PlacedFootprint.Footprint.RowPitch = aligned_row_pitch;
 

--- a/src/render_tasks/d3d12_pixel_data_readback.hpp
+++ b/src/render_tasks/d3d12_pixel_data_readback.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "../d3d12/d3d12_structs.hpp"
-#include "../d3d12/d3d12_renderer.hpp"
-#include "../d3d12/d3d12_functions.hpp"
-#include "../frame_graph/frame_graph.hpp"
+#include "d3d12/d3d12_functions.hpp"
+#include "d3d12/d3d12_renderer.hpp"
+#include "d3d12/d3d12_structs.hpp"
+#include "frame_graph/frame_graph.hpp"
+#include "util/math.hpp"
 
 namespace wr
 {
@@ -71,7 +72,11 @@ namespace wr
 			destination.PlacedFootprint.Footprint.Width = dx12_render_system.m_viewport.m_viewport.Width;
 			destination.PlacedFootprint.Footprint.Height = dx12_render_system.m_viewport.m_viewport.Height;
 			destination.PlacedFootprint.Footprint.Depth = 1;
-			destination.PlacedFootprint.Footprint.RowPitch = destination.PlacedFootprint.Footprint.Width * BytesPerPixel(data.predecessor_render_target->m_create_info.m_rtv_formats[0]);
+
+			std::uint32_t row_pitch = destination.PlacedFootprint.Footprint.Width * BytesPerPixel(data.predecessor_render_target->m_create_info.m_rtv_formats[0]);
+			std::uint32_t aligned_row_pitch = util::RoundUpToNearestMultiple(row_pitch, 256);	// 256 byte aligned
+
+			destination.PlacedFootprint.Footprint.RowPitch = aligned_row_pitch;
 
 			D3D12_TEXTURE_COPY_LOCATION source = {};
 			source.pResource = data.predecessor_render_target->m_render_targets[0];

--- a/src/scene_graph/camera_node.cpp
+++ b/src/scene_graph/camera_node.cpp
@@ -6,7 +6,7 @@ namespace wr
 
 	void CameraNode::SetFov(float deg)
 	{
-		m_fov = deg / 180 * 3.1415926535f;
+		m_fov = deg / 180.0f * 3.1415926535f;
 		SignalChange();
 	}
 

--- a/src/util/math.hpp
+++ b/src/util/math.hpp
@@ -18,20 +18,4 @@ namespace util
 
 		return upper3x3;
 	}
-
-	// https://stackoverflow.com/a/3407254
-	//! Round the input number to the nearest multiple of the specified number
-	/*! \param input Number to round. 
-	 *  \param multiple Multiple to round the input to. */
-	inline std::uint32_t RoundUpToNearestMultiple(std::uint32_t input, std::uint32_t multiple)
-	{
-		if (multiple == 0)
-			return input;
-
-		std::uint32_t remainder = input % multiple;
-		if (remainder == 0)
-			return input;
-
-		return input + multiple - remainder;
-	}
 } /* util */

--- a/src/util/math.hpp
+++ b/src/util/math.hpp
@@ -19,4 +19,19 @@ namespace util
 		return upper3x3;
 	}
 
+	// https://stackoverflow.com/a/3407254
+	//! Round the input number to the nearest multiple of the specified number
+	/*! \param input Number to round. 
+	 *! \param multiple Multiple to round the input to. */
+	inline std::uint32_t RoundUpToNearestMultiple(std::uint32_t input, std::uint32_t multiple)
+	{
+		if (multiple == 0)
+			return input;
+
+		std::uint32_t remainder = input % multiple;
+		if (remainder == 0)
+			return input;
+
+		return input + multiple - remainder;
+	}
 } /* util */

--- a/src/util/math.hpp
+++ b/src/util/math.hpp
@@ -22,7 +22,7 @@ namespace util
 	// https://stackoverflow.com/a/3407254
 	//! Round the input number to the nearest multiple of the specified number
 	/*! \param input Number to round. 
-	 *! \param multiple Multiple to round the input to. */
+	 *  \param multiple Multiple to round the input to. */
 	inline std::uint32_t RoundUpToNearestMultiple(std::uint32_t input, std::uint32_t multiple)
 	{
 		if (multiple == 0)


### PR DESCRIPTION
We've always tested the plug-in using a resolution of 1280*720. This is a perfect multiple of 256 when calculating the row pitch of a buffer by doing width*bytes per pixel.

This pull request adds support for non perfect 256-byte row pitches. The code now adds padding whenever needed.