### PR TITLE
Option to override projection matrix

### DIFF
--- a/src/scene_graph/camera_node.cpp
+++ b/src/scene_graph/camera_node.cpp
@@ -39,8 +39,12 @@ namespace wr
 		DirectX::XMVECTOR right = DirectX::XMVector3Normalize(m_transform.r[0]);
 
 		m_view = DirectX::XMMatrixLookToRH(pos, forward, up);
+		
+		if (!m_override_projection)
+		{
+			m_projection = DirectX::XMMatrixPerspectiveFovRH(m_fov.m_fov, m_aspect_ratio, m_frustum_near, m_frustum_far);
+		}
 
-		m_projection = DirectX::XMMatrixPerspectiveFovRH(m_fov.m_fov, m_aspect_ratio, m_frustum_near, m_frustum_far);
 		m_view_projection = m_view * m_projection;
 		m_inverse_projection = DirectX::XMMatrixInverse(nullptr, m_projection);
 		m_inverse_view = DirectX::XMMatrixInverse(nullptr, m_view);

--- a/src/scene_graph/camera_node.hpp
+++ b/src/scene_graph/camera_node.hpp
@@ -41,7 +41,8 @@ namespace wr
 			m_f_number(32.0f),
 			m_shape_amt(0.0f),
 			m_aperture_blades(5),
-			m_focus_dist(0)
+			m_focus_dist(0),
+			m_override_projection(false)
 		{
 		}
 
@@ -71,6 +72,7 @@ namespace wr
 		float m_shape_amt;
 		int m_aperture_blades;
 		bool m_enable_dof = false;
+		bool m_override_projection;
 
 		FoV m_fov;
 


### PR DESCRIPTION
Added an option to disable the creation of the projection matrix in the camera node. This option is mostly meant for the Maya plugin.