### PR TITLE
Feature shader reloading

### DIFF
--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -538,8 +538,15 @@ namespace wr
 			}
 			else
 			{
-				std::cout << std::get<std::string>(shader_error) << std::endl;
-				LOGC(std::get<std::string>(shader_error));
+				try
+				{
+					LOGC(std::get<std::string>(shader_error));
+				}
+				catch(std::exception e)
+				{
+					std::cerr << "Seems like FMT failed to format the error message. Using cout instead." << std::endl;
+					std::cerr << std::get<std::string>(shader_error) << std::endl;
+				}
 			}
 		}
 	}

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -544,7 +544,7 @@ namespace wr
 				}
 				catch(std::exception e)
 				{
-					std::cerr << "Seems like FMT failed to format the error message. Using cout instead." << std::endl;
+					LOGW("Seems like FMT failed to format the error message. Using cout instead.");
 					std::cerr << std::get<std::string>(shader_error) << std::endl;
 				}
 			}


### PR DESCRIPTION
No longer crashes when fmt fails to format an shader error message.